### PR TITLE
Add config for Heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,5 +12,22 @@
     {
       "url": "heroku/python"
     }
-  ]
+  ],
+  "env": {
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "DJANGO_SECRET_KEY": {
+      "generator": "secret"
+    },
+    "CONTENT_TYPE_NO_SNIFF": "True",
+    "CORS_WHITELIST": "*",
+    "DEBUG": "False",
+    "NPM_CONFIG_PRODUCTION": "true",
+    "USE_S3": "False",
+    "SET_HSTS": "True",
+    "SSL_REDIRECT": "True",
+    "X_FRAME_OPTIONS": "DENY",
+    "XSS_PROTECTION": "True"
+  }
 }


### PR DESCRIPTION
I used the `env.default` [defined here](https://github.com/mozilla/donate-wagtail/pull/8/files#diff-a4bd1549b96ed846746d971768b08f42) as a template.