### PR TITLE
Add scaffolding to keep track of the source page for any payment journey

### DIFF
--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -44,7 +44,7 @@ class DonationPage(Page):
             'currencies': self.currencies,
             'initial_currency_info': get_currency_info(initial_currency),
             'braintree_params': settings.BRAINTREE_PARAMS,
-            'braintree_form': BraintreePaypalPaymentForm(),
+            'braintree_form': BraintreePaypalPaymentForm(initial={'source_page_id': self.pk}),
             'currency_form': CurrencyForm(initial={'currency': initial_currency}),
         })
         return ctx

--- a/donate/core/tests/test_models.py
+++ b/donate/core/tests/test_models.py
@@ -26,12 +26,24 @@ class DonationPageTestCase(TestCase):
 
     def test_serve_sets_subscribed_cookie(self):
         request = RequestFactory().get('/?subscribed=1')
-        response = DonationPage().serve(request)
+        site_root = Page.objects.first()
+        page = LandingPageFactory.create(
+            parent=site_root,
+            title='Donate today',
+            slug='landing',
+        )
+        response = page.serve(request)
         self.assertEqual(response.cookies['subscribed'].value, '1')
 
     def test_serve_doesnt_set_subscribed_cookie_if_invalid_query_arg(self):
         request = RequestFactory().get('/?subscribed=foo')
-        response = DonationPage().serve(request)
+        site_root = Page.objects.first()
+        page = LandingPageFactory.create(
+            parent=site_root,
+            title='Donate today',
+            slug='landing',
+        )
+        response = page.serve(request)
         self.assertNotIn('subscribed', response.cookies)
 
 

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -10,6 +10,7 @@ from . import constants
 class StartCardPaymentForm(forms.Form):
     amount = forms.DecimalField(min_value=0.01, decimal_places=2)
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES)
+    source_page_id = forms.IntegerField(widget=forms.HiddenInput)
 
 
 class BraintreePaymentForm(forms.Form):
@@ -31,6 +32,7 @@ class BraintreeCardPaymentForm(BraintreePaymentForm):
 class BraintreePaypalPaymentForm(BraintreePaymentForm):
     frequency = forms.ChoiceField(choices=constants.FREQUENCY_CHOICES, widget=forms.HiddenInput)
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES, widget=forms.HiddenInput)
+    source_page_id = forms.IntegerField(widget=forms.HiddenInput)
 
 
 class CurrencyForm(forms.Form):

--- a/donate/payments/tests/test_views.py
+++ b/donate/payments/tests/test_views.py
@@ -9,7 +9,9 @@ from django.views.generic import FormView
 from braintree import ErrorCodes, ErrorResult
 from freezegun import freeze_time
 from freezegun.api import FakeDate
+from wagtail.core.models import Page
 
+from donate.core.factory.core_pages import LandingPageFactory
 from ..forms import (
     BraintreePaymentForm, BraintreeCardPaymentForm, BraintreePaypalPaymentForm,
     BraintreePaypalUpsellForm, UpsellForm
@@ -57,6 +59,9 @@ class BraintreeMixinTestView(BraintreePaymentMixin, FormView):
             'some': 'data'
         }
 
+    def get_source_page_id(self):
+        return 3
+
 
 class BraintreeMixinTestCase(TestCase):
 
@@ -73,6 +78,7 @@ class BraintreeMixinTestCase(TestCase):
             'amount': '50',
             'some': 'data',
         })
+        self.assertEqual(view.request.session['source_page_id'], 3)
 
 
 class CardPaymentViewTestCase(TestCase):
@@ -82,12 +88,11 @@ class CardPaymentViewTestCase(TestCase):
             'first_name': 'Alice',
             'last_name': 'Bob',
             'email': 'alice@example.com',
-            'phone_number': '+442088611222',
             'address_line_1': '1 Oak Tree Hill',
             'town': 'New York',
             'post_code': '10022',
             'country': 'US',
-            'amount': 50,
+            'amount': Decimal(50),
             'braintree_nonce': 'hello-braintree',
         }
 
@@ -96,6 +101,7 @@ class CardPaymentViewTestCase(TestCase):
         self.view = CardPaymentView()
         self.view.payment_frequency = 'single'
         self.view.currency = 'usd'
+        self.view.source_page_id = 3
         self.view.request = self.request
 
         self.fake_error_result = ErrorResult("gateway", {
@@ -259,6 +265,9 @@ class CardPaymentViewTestCase(TestCase):
             }
         })
 
+    def test_get_source_page_id(self):
+        self.assertEqual(self.view.get_source_page_id(), 3)
+
 
 class SingleCardPaymentViewTestCase(CardPaymentViewTestCase):
 
@@ -296,6 +305,25 @@ class SingleCardPaymentViewTestCase(CardPaymentViewTestCase):
             self.view.get_success_url(),
             reverse('payments:card_upsell')
         )
+
+    def test_get_transaction_details_for_session(self):
+        form = BraintreeCardPaymentForm(self.form_data)
+        assert form.is_valid()
+        details = self.view.get_transaction_details_for_session(
+            MockBraintreeResult(),
+            form,
+            payment_method_token='token-1'
+        )
+
+        expected_details = self.form_data.copy()
+        expected_details.update({
+            'transaction_id': 'transaction-id-1',
+            'payment_method': 'card',
+            'payment_frequency': 'single',
+            'payment_method_token': 'token-1',
+            'currency': 'usd',
+        })
+        self.assertEqual(details, expected_details)
 
 
 class MonthlyCardPaymentViewTestCase(CardPaymentViewTestCase):
@@ -344,6 +372,25 @@ class MonthlyCardPaymentViewTestCase(CardPaymentViewTestCase):
             reverse('payments:newsletter_signup')
         )
 
+    def test_get_transaction_details_for_session(self):
+        form = BraintreeCardPaymentForm(self.form_data)
+        assert form.is_valid()
+        details = self.view.get_transaction_details_for_session(
+            MockBraintreeSubscriptionResult(),
+            form,
+            payment_method_token='token-1'
+        )
+
+        expected_details = self.form_data.copy()
+        expected_details.update({
+            'transaction_id': 'subscription-id-1',
+            'payment_method': 'card',
+            'payment_frequency': 'monthly',
+            'payment_method_token': 'token-1',
+            'currency': 'usd',
+        })
+        self.assertEqual(details, expected_details)
+
 
 class PaypalPaymentViewTestCase(TestCase):
 
@@ -356,7 +403,8 @@ class PaypalPaymentViewTestCase(TestCase):
             'braintree_nonce': 'hello-braintree',
             'amount': Decimal(10),
             'currency': 'usd',
-            'frequency': 'single'
+            'frequency': 'single',
+            'source_page_id': 3
         }
 
     def test_transaction_data_submitted_to_braintree(self):
@@ -425,6 +473,10 @@ class PaypalPaymentViewTestCase(TestCase):
             }
         )
 
+    def test_get_source_page_id(self):
+        self.view.source_page_id = 3
+        self.assertEqual(self.view.get_source_page_id(), 3)
+
     def test_get_success_url_single(self):
         self.view.payment_frequency = 'single'
         self.assertEqual(
@@ -450,6 +502,27 @@ class TransactionRequiredMixinTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['Location'], '/')
 
+    def test_get_source_page(self):
+        landing_page = LandingPageFactory.create(
+            parent=Page.objects.first(),
+            title='Donate today',
+            slug='landing',
+        )
+        view = TransactionRequiredMixin()
+        view.request = RequestFactory().get('/')
+        view.request.session = {
+            'source_page_id': landing_page.pk,
+        }
+        self.assertEqual(view.get_source_page(), landing_page)
+
+    def test_get_source_page_invalid_id(self):
+        view = TransactionRequiredMixin()
+        view.request = RequestFactory().get('/')
+        view.request.session = {
+            'source_page_id': 14,
+        }
+        self.assertIsNone(view.get_source_page())
+
 
 class CardUpsellViewTestCase(TestCase):
 
@@ -460,7 +533,6 @@ class CardUpsellViewTestCase(TestCase):
                 'first_name': 'Alice',
                 'last_name': 'Bob',
                 'email': 'alice@example.com',
-                'phone_number': '+442088611222',
                 'address_line_1': '1 Oak Tree Hill',
                 'town': 'New York',
                 'post_code': '10022',
@@ -470,7 +542,8 @@ class CardUpsellViewTestCase(TestCase):
                 'payment_frequency': 'single',
                 'payment_method': 'card',
                 'payment_method_token': 'payment-method-1',
-            }
+            },
+            'source_page_id': 3,
         }
         self.view = CardUpsellView()
         self.view.request = self.request
@@ -536,6 +609,9 @@ class CardUpsellViewTestCase(TestCase):
             }
         )
 
+    def test_get_source_page_id(self):
+        self.assertEqual(self.view.get_source_page_id(), 3)
+
 
 class PaypalUpsellViewTestCase(TestCase):
 
@@ -548,7 +624,8 @@ class PaypalUpsellViewTestCase(TestCase):
                 'payment_frequency': 'single',
                 'payment_method': 'paypal',
                 'payment_method_token': 'payment-method-1',
-            }
+            },
+            'source_page_id': 3,
         }
         self.view = PaypalUpsellView()
         self.view.request = self.request
@@ -624,6 +701,9 @@ class PaypalUpsellViewTestCase(TestCase):
                 'payment_frequency': 'monthly',
             }
         )
+
+        def test_get_source_page_id(self):
+            self.assertEqual(self.view.get_source_page_id(), 3)
 
 
 class NewsletterSignupViewTestCase(TestCase):

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -17,6 +17,7 @@
         </form>
         <div class="tabs__panel js-tab-panel" id="tab-panel-1" role="tabpanel" aria-labelledby="tab-1">
             <form method="GET" id="donate-form--single">
+                <input type="hidden" name="source_page_id" value="{{ page.pk }}">
                 <input type="hidden" name="currency" value="{{ initial_currency_info.code }}" class="js-form-currency">
 
                 <div class="donate-form__fields" id="js-donate-form-single">
@@ -74,6 +75,7 @@
         </div>
         <div class="js-tab-panel tabs__panel tabs__panel--hidden" id="tab-panel-2" role="tabpanel" aria-labelledby="tab-2">
             <form method="GET" id="donate-form--monthly">
+                <input type="hidden" name="source_page_id" value="{{ page.pk }}">
                 <input type="hidden" name="currency" value="{{ initial_currency_info.code }}" class="js-form-currency">
 
                 <div class="donate-form__fields" id="js-donate-form-monthly">
@@ -139,6 +141,7 @@
         {% render_form_field braintree_form.amount %}
         {% render_form_field braintree_form.frequency %}
         {% render_form_field braintree_form.currency %}
+        {% render_form_field braintree_form.source_page_id %}
     </form>
 
     <footer class="donate-form__footer">


### PR DESCRIPTION
Store the ID of the originating page in the session at the end of a transaction. This will be used to gather data required for #27.

Also added some missing tests for `get_transaction_details_for_session` for single/monthly card views.