### PR TITLE
Add locale-based currency formatting.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,7 @@ boto3 = "*"
 braintree = "*"
 django-countries = "*"
 freezegun = "*"
+py-moneyed = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2ad9126bd9aea10d5d9a3a1351c3e9b597b5db97a2e15a958cf4c33027a18d18"
+            "sha256": "dc67954be6c1395a597117d87054e7b29427657c55b1f5bd234393c382ec29ba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -71,11 +71,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:4d23f61b26892bac785f07401bc38cbf8fa4cec993f400e9cd9ddf28fd51c0ea",
-                "sha256:6e974d4b57e3b29e4882b244d40171d6a75202ab8d2402b8e8adbd182e25cf0c"
+                "sha256:16a5d54411599780ac9dfe3b9b38f90f785c51259a584e0b24b6f14a7f69aae8",
+                "sha256:9a2f98211ab474c710fcdad29c82f30fc14ce9917c7a70c3682162a624de4035"
             ],
             "index": "pypi",
-            "version": "==2.2.3"
+            "version": "==2.2.4"
         },
         "django-countries": {
             "hashes": [
@@ -271,6 +271,14 @@
             "index": "pypi",
             "version": "==2.8.3"
         },
+        "py-moneyed": {
+            "hashes": [
+                "sha256:c6691b914a5e4b5b2335cf113620479a52cc82988c0e143435a7c5c7d60cd4ad",
+                "sha256:ec73795171919d537880a33c44d07fcdf0a5225e8368684fe02f0e75a6404742"
+            ],
+            "index": "pypi",
+            "version": "==0.8.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
@@ -281,10 +289,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
-                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
+                "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
+                "sha256:c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"
             ],
-            "version": "==2019.1"
+            "version": "==2019.2"
         },
         "redis": {
             "hashes": [
@@ -479,27 +487,29 @@
         },
         "python-coveralls": {
             "hashes": [
-                "sha256:38a8c55849308b136f9b831e7ac972f9b6d0068d0087cd75dc147ac6a0e8e360",
-                "sha256:f044de08b547cfa3cd6e120cd4656e217b9ff012a4211ed11a60016e1362223e"
+                "sha256:bfaf7811e7dc5628e83b6b162962a4e2485dbff184b30e49f380374ed1bcee55",
+                "sha256:fb0ff49bb1551dac10b06bd55e9790287d898a0f1e2c959802235cae08dd0bff"
             ],
             "index": "pypi",
-            "version": "==2.9.2"
+            "version": "==2.9.3"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:57acc1d8533cbe51f6662a55434f0dbecfa2b9eaf115bede8f6fd00115a0c0d3",
-                "sha256:588c94b3d16b76cfed8e0be54932e5729cc185caffaa5a451e7ad2f7ed8b4043",
-                "sha256:68c8dd247f29f9a0d09375c9c6b8fdc64b60810ebf07ba4cdd64ceee3a58c7b7",
-                "sha256:70d9818f1c9cd5c48bb87804f2efc8692f1023dac7f1a1a5c61d454043c1d265",
-                "sha256:86a93cccd50f8c125286e637328ff4eef108400dd7089b46a7be3445eecfa391",
-                "sha256:a0f329125a926876f647c9fa0ef32801587a12328b4a3c741270464e3e4fa778",
-                "sha256:a3c252ab0fa1bb0d5a3f6449a4826732f3eb6c0270925548cac342bc9b22c225",
-                "sha256:b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955",
-                "sha256:cd0618c5ba5bda5f4039b9398bb7fb6a317bb8298218c3de25c47c4740e4b95e",
-                "sha256:ceacb9e5f8474dcf45b940578591c7f3d960e82f926c707788a570b51ba59190",
-                "sha256:fe6a88094b64132c4bb3b631412e90032e8cfe9745a58370462240b8cb7553cd"
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
             ],
-            "version": "==5.1.1"
+            "version": "==5.1.2"
         },
         "requests": {
             "hashes": [

--- a/donate/core/templatetags/util_tags.py
+++ b/donate/core/templatetags/util_tags.py
@@ -1,4 +1,10 @@
+from decimal import Decimal
+
 from django import template
+from django.utils.translation import to_locale
+
+from moneyed import get_currency, Money
+from moneyed.localization import format_money, _FORMATTER
 
 register = template.Library()
 
@@ -6,3 +12,24 @@ register = template.Library()
 @register.filter
 def is_english(language_code):
     return language_code.startswith('en')
+
+
+@register.simple_tag(takes_context=True)
+def get_locale(context):
+    return to_locale(context['request'].LANGUAGE_CODE)
+
+
+@register.simple_tag(takes_context=True)
+def format_currency(context, currency_code, amount):
+    locale = to_locale(context['request'].LANGUAGE_CODE)
+    currency_obj = get_currency(currency_code.upper())
+    amount = Decimal(amount)
+    exponent = amount.as_tuple().exponent
+    return format_money(Money(amount, currency_obj), locale=locale, decimal_places=-exponent)
+
+
+@register.simple_tag(takes_context=True)
+def get_localized_currency_symbol(context, currency_code):
+    locale = to_locale(context['request'].LANGUAGE_CODE)
+    prefix, suffix = _FORMATTER.get_sign_definition(currency_code.upper(), locale)
+    return prefix.strip() or suffix.strip()

--- a/donate/core/tests/test_templatetags.py
+++ b/donate/core/tests/test_templatetags.py
@@ -1,0 +1,68 @@
+from django.test import TestCase, RequestFactory
+
+from ..templatetags.util_tags import format_currency, get_localized_currency_symbol
+
+
+class UtilTagsTestCase(TestCase):
+    """
+    These are integration tests that sanity check the output of key template tags.
+    """
+
+    def setUp(self):
+        self.request = RequestFactory().get('/')
+
+    def test_format_currency_usd_en_us(self):
+        self.request.LANGUAGE_CODE = 'en-US'
+        ctx = {
+            'request': self.request
+        }
+        value = format_currency(ctx, 'usd', 1)
+        self.assertEqual(value, '$1')
+
+    def test_format_currency_usd_en_us_decimal(self):
+        self.request.LANGUAGE_CODE = 'en-US'
+        ctx = {
+            'request': self.request
+        }
+        value = format_currency(ctx, 'usd', 1.5)
+        self.assertEqual(value, '$1.5')
+
+    def test_format_currency_usd_en_gb(self):
+        self.request.LANGUAGE_CODE = 'en-GB'
+        ctx = {
+            'request': self.request
+        }
+        value = format_currency(ctx, 'usd', 1)
+        self.assertEqual(value, 'US$1')
+
+    def test_format_currency_aed_en_us(self):
+        self.request.LANGUAGE_CODE = 'en-US'
+        ctx = {
+            'request': self.request
+        }
+        value = format_currency(ctx, 'aed', 1)
+        self.assertEqual(value, 'Dhs1')
+
+    def test_format_currency_aed_ar(self):
+        self.request.LANGUAGE_CODE = 'ar'
+        ctx = {
+            'request': self.request
+        }
+        value = format_currency(ctx, 'aed', 1)
+        self.assertEqual(value, 'د.إ1')
+
+    def test_get_localised_symbol_usd_en_us(self):
+        self.request.LANGUAGE_CODE = 'en-US'
+        ctx = {
+            'request': self.request
+        }
+        value = get_localized_currency_symbol(ctx, 'usd')
+        self.assertEqual(value, '$')
+
+    def test_get_localised_symbol_usd_en_gb(self):
+        self.request.LANGUAGE_CODE = 'en-GB'
+        ctx = {
+            'request': self.request
+        }
+        value = get_localized_currency_symbol(ctx, 'usd')
+        self.assertEqual(value, 'US$')

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -1,5 +1,5 @@
-{% load i18n form_tags %}
-<div class="donate-form__content" id="js-donate-form">
+{% load i18n form_tags util_tags %}
+<div class="donate-form__content" id="js-donate-form" data-locale="{% get_locale %}">
     <div class="donate-form__tabs tabs js-tabs">
         <form class="donate-form__tab-options tabs__container" role="tablist">
             <div class="tabs__option" role="presentation">
@@ -24,14 +24,14 @@
                     <div class="donation-amount">
                         <input type="radio" class="donation-amount__radio" name="amount" value="{{ amount }}" id="one-time-amount-{{ forloop.counter0 }}" autocomplete="off" {% if forloop.first %}checked{% endif %}>
                         <label for="one-time-amount-{{ forloop.counter0 }}" class="donation-amount__label">
-                            {{ initial_currency_info.symbol }}{{ amount }}
+                            {% format_currency initial_currency_info.code amount %}
                         </label>
                     </div>
                     {% endfor %}
 
                     <div class="donation-amount donation-amount--two-col donation-amount--other">
                         <input type="radio" class="donation-amount__radio" name="amount" value="other" id="one-time-amount-other" autocomplete="off" data-other-amount-radio="">
-                        <label for="one-time-amount-other" class="donation-amount__label" data-currency="">{{ initial_currency_info.symbol }}</label>
+                        <label for="one-time-amount-other" class="donation-amount__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                         <label for="one-time-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
                         <input type="text" class="donation-amount__input" name="one-time-amount-other-input" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" data-other-amount="">
                     </div>
@@ -81,14 +81,14 @@
                     <div class="donation-amount">
                         <input type="radio" class="donation-amount__radio" name="amount" value="{{ amount }}" id="monthly-amount-{{ forloop.counter0 }}" autocomplete="off" {% if forloop.first %}checked{% endif %}>
                         <label for="monthly-amount-{{ forloop.counter0 }}" class="donation-amount__label">
-                            {{ initial_currency_info.symbol }}{{ amount }} {% trans "per month" %}
+                            {% format_currency initial_currency_info.code amount %}
                         </label>
                     </div>
                     {% endfor %}
 
                     <div class="donation-amount donation-amount--two-col donation-amount--other">
                         <input type="radio" class="donation-amount__radio" name="amount" value="other" id="monthly-amount-other" autocomplete="off" data-other-amount-radio="">
-                        <label for="monthly-amount-other" class="donation-amount__label" data-currency="">{{ initial_currency_info.symbol }}</label>
+                        <label for="monthly-amount-other" class="donation-amount__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                         <label for="monthly-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
                         <input type="text" class="donation-amount__input" name="monthly-amount-other-input" id="monthly-amount-other-input" placeholder="Other amount" data-other-amount="">
                     </div>

--- a/donate/templates/payment/card.html
+++ b/donate/templates/payment/card.html
@@ -1,5 +1,5 @@
 {% extends "pages/base_page.html" %}
-{% load i18n form_tags static %}
+{% load i18n form_tags static util_tags %}
 
 {% block title %}{% trans "Your information" %}{% endblock %}
 
@@ -15,13 +15,12 @@
                 <div class="notification notification--neutral">
                     <div class="notification__container">
                         <div class="notification__message">
-                            {% with amount=form.amount.value|floatformat:"-2" symbol=currency_info.symbol span_class='js-donation-value' %}
+                            {% format_currency currency_info.code form.amount.value as formatted_amount %}
                             {% if payment_frequency == 'monthly' %}
-                                {% blocktrans with symbol=symbol amount=amount span_class=span_class %}You are donating {{ symbol }} <span class="{{ span_class }}">{{ amount }}</span> per month{% endblocktrans %}
+                                {% blocktrans with formatted_amount=formatted_amount span_class='js-donation-value' %}You are donating <span class="{{ span_class }}">{{ formatted_amount }}</span> per month{% endblocktrans %}
                             {% else %}
-                                {% blocktrans with symbol=symbol amount=amount span_class=span_class %}You are donating {{ symbol }} <span class="{{ span_class }}">{{ amount }}</span>{% endblocktrans %}
+                                {% blocktrans with formatted_amount=formatted_amount span_class='js-donation-value' %}You are donating <span class="{{ span_class }}">{{ formatted_amount }}</span>{% endblocktrans %}
                             {% endif %}
-                            {% endwith %}
                         </div>
                         <div class="notification__action">
                             <a href="#donate__amount-edit" class="donation-update__toggle" data-amount-toggle>{% trans "Change amount" %}</a>
@@ -30,10 +29,10 @@
                 </div>
 
                 <div class="donation-update" data-amount-actions>
-                    <form class="donation-update__container" id="js-update-donation-amount-form">
+                    <form class="donation-update__container" id="js-update-donation-amount-form" data-currency="{{ currency_info.code }}" data-locale="{% get_locale %}">
                         <div class="donation-update__form-item form-item">
                             <label class="donation-update__label form-item__label" for="donation-update">{% trans "Donation Amount" %}</label>
-                            <div class="donation-update__currency-symbol">{{ currency_info.symbol }}</div>
+                            <div class="donation-update__currency-symbol">{% get_localized_currency_symbol currency_info.code %}</div>
                             <input class="donation-update__input form-item__input" id="js-update-donation-value" type="number" name="donation-update" value="{{ form.amount.value }}" step="1" min="1" required>
                         </div>
                         <div class="form-item">
@@ -133,7 +132,8 @@
                                 <svg class="button__icon" width="24" height="24">
                                     <use xlink:href="#padlock"></use>
                                 </svg>
-                                {% blocktrans with symbol=currency_info.symbol amount=form.amount.value|floatformat:"-2" %}Donate {{ symbol }} <span class="js-donation-value">{{ amount }}</span>{% endblocktrans %}
+                                {% format_currency currency_info.code form.amount.value as formatted_amount %}
+                                {% blocktrans with formatted_amount=formatted_amount %}Donate <span class="js-donation-value">{{ formatted_amount }}</span>{% endblocktrans %}
                             </button>
 
                         </div>

--- a/donate/templates/payment/card.html
+++ b/donate/templates/payment/card.html
@@ -132,8 +132,10 @@
                                 <svg class="button__icon" width="24" height="24">
                                     <use xlink:href="#padlock"></use>
                                 </svg>
-                                {% format_currency currency_info.code form.amount.value as formatted_amount %}
-                                {% blocktrans with formatted_amount=formatted_amount %}Donate <span class="js-donation-value">{{ formatted_amount }}</span>{% endblocktrans %}
+                                <div class="button__label">
+                                    {% format_currency currency_info.code form.amount.value as formatted_amount %}
+                                    {% blocktrans with formatted_amount=formatted_amount %}Donate <span class="button__value js-donation-value">{{ formatted_amount }}</span>{% endblocktrans %}
+                                </div>
                             </button>
 
                         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4624,8 +4624,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4643,13 +4642,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4662,18 +4659,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4776,8 +4770,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4787,7 +4780,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4800,20 +4792,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4830,7 +4819,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4903,8 +4891,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4914,7 +4901,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4990,8 +4976,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5021,7 +5006,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5039,7 +5023,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5078,13 +5061,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/source/js/components/currency-selector.js
+++ b/source/js/components/currency-selector.js
@@ -6,6 +6,9 @@ class CurrencySelect {
   constructor(node) {
     this.selectMenu = node;
     this.formContainer = document.getElementById("js-donate-form");
+    // Convert a locale provided by Django in the form en_US to a
+    // BCP 47 compliant tag in the form en-US.
+    // See https://tools.ietf.org/html/bcp47
     this.locale = this.formContainer
       .getAttribute("data-locale")
       .replace("_", "-");

--- a/source/js/components/donation-amount-toggle.js
+++ b/source/js/components/donation-amount-toggle.js
@@ -13,6 +13,14 @@ class AmountToggle {
     this.activeClass = "active";
     this.selectedClass = "selected";
 
+    let locale = this.updateForm.getAttribute("data-locale").replace("_", "-");
+    let currency = this.updateForm.getAttribute("data-currency").toUpperCase();
+    this.formatter = new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency: currency,
+      minimumFractionDigits: 0
+    });
+
     this.bindEvents();
   }
 
@@ -28,7 +36,9 @@ class AmountToggle {
 
   UpdatePageDonationAmount() {
     document.querySelectorAll(".js-donation-value").forEach(donationAmount => {
-      donationAmount.textContent = this.hiddenInput.value;
+      donationAmount.textContent = this.formatter.format(
+        this.hiddenInput.value
+      );
     });
   }
 


### PR DESCRIPTION
See #140, #93. This PR adds locale-based currency formatting in two ways:

1. Currencies rendered in Django templates are formatted using `moneyed`.

2. Values manipulated in JS are formatted using `Intl.NumberFormat`.

Worth noting that `Intl` is not supported in IE10 and below - if this is a problem we're going to need a polyfill.

I haven't removed the currency symbols defined in `constants.py` - ideally we would rely on `moneyed` to provide these, but it doesn't make this at all easy to do outside of a locale context, so I've gone with using our symbols as a fallback.

@nicklee I have a small display issue, where the space between "Donate " and the currency is being lost on the button on the card details view - this I _think_ is due to flex styling but I am not sure how best to resolve. Grateful if you can have a look at that and also review the JS changes.