### PR TITLE
Drop py-moneyed in favour of babel.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,7 @@ boto3 = "*"
 braintree = "*"
 django-countries = "*"
 freezegun = "*"
-py-moneyed = "*"
+babel = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dc67954be6c1395a597117d87054e7b29427657c55b1f5bd234393c382ec29ba"
+            "sha256": "76f11589b0639bae4f3401b89ef4b460e44aebfd745cfc9a732a3f3625578a2e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "babel": {
+            "hashes": [
+                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
+                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
+            ],
+            "index": "pypi",
+            "version": "==2.7.0"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:11a9a27b7d3bddc6d86f59fb76afb70e921a25ac2d6cc55b40d072bd68435a76",
@@ -26,18 +34,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0cd4a3e158f40eedb54b36b3fbe60d135db74a245f0ca8eead1af2eb6d46a649",
-                "sha256:68e9eba6f846cf8e01973ec565afdb1adfb9612b531c15bb5c5524394db4df5b"
+                "sha256:666f37c5852f71925494fc2103b189deafe6702c1d9ae60bead5b1b6466de857",
+                "sha256:7b77b507221ec15550b02d492804166bcc61ef3a81312968065515a76aa1791b"
             ],
             "index": "pypi",
-            "version": "==1.9.199"
+            "version": "==1.9.202"
         },
         "botocore": {
             "hashes": [
-                "sha256:25d87047241b7b775443570c0e790ca952f9f7491d4d6472430a4b006383a257",
-                "sha256:e4729c1acaa936d4c5c948a18d279f92bbf61fad9b5fb03942c753ec405e427d"
+                "sha256:71ca578701e746fe947c098e5dee06128d0f6ba98217ba7e29aff0dab8caf82f",
+                "sha256:e55003c46e71396a551d4b70f39286f8fc4094ac6cf90f5db8d7a68bb4af1f9d"
             ],
-            "version": "==1.12.199"
+            "version": "==1.12.202"
         },
         "braintree": {
             "hashes": [
@@ -271,14 +279,6 @@
             "index": "pypi",
             "version": "==2.8.3"
         },
-        "py-moneyed": {
-            "hashes": [
-                "sha256:c6691b914a5e4b5b2335cf113620479a52cc82988c0e143435a7c5c7d60cd4ad",
-                "sha256:ec73795171919d537880a33c44d07fcdf0a5225e8368684fe02f0e75a6404742"
-            ],
-            "index": "pypi",
-            "version": "==0.8.0"
-        },
         "python-dateutil": {
             "hashes": [
                 "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
@@ -296,10 +296,10 @@
         },
         "redis": {
             "hashes": [
-                "sha256:1f2493b72f669a096c59ca7cf7f4067b1ab58a0a3c6bef51d5d8fd384298c6a2",
-                "sha256:b851b0ef53b6d416f1dc692dc168f3d390b37995925bfe29351b3a869976598c"
+                "sha256:45682ecf226c7611efe731974c4fa3390170ba045b9cdb26f0051114a5c2a68b",
+                "sha256:f2609a85e5f37f489ba3b5652e1175dc3711c4d7a7818c4f657615810afd23df"
             ],
-            "version": "==3.3.4"
+            "version": "==3.3.6"
         },
         "requests": {
             "hashes": [

--- a/donate/core/tests/test_templatetags.py
+++ b/donate/core/tests/test_templatetags.py
@@ -11,7 +11,7 @@ class UtilTagsTestCase(TestCase):
     def setUp(self):
         self.request = RequestFactory().get('/')
 
-    def test_format_currency_usd_en_us(self):
+    def test_format_currency_usd_en_us_integer(self):
         self.request.LANGUAGE_CODE = 'en-US'
         ctx = {
             'request': self.request
@@ -25,7 +25,7 @@ class UtilTagsTestCase(TestCase):
             'request': self.request
         }
         value = format_currency(ctx, 'usd', 1.5)
-        self.assertEqual(value, '$1.5')
+        self.assertEqual(value, '$1.50')
 
     def test_format_currency_usd_en_gb(self):
         self.request.LANGUAGE_CODE = 'en-GB'
@@ -41,7 +41,7 @@ class UtilTagsTestCase(TestCase):
             'request': self.request
         }
         value = format_currency(ctx, 'aed', 1)
-        self.assertEqual(value, 'Dhs1')
+        self.assertEqual(value, 'AED1')
 
     def test_format_currency_aed_ar(self):
         self.request.LANGUAGE_CODE = 'ar'
@@ -49,7 +49,7 @@ class UtilTagsTestCase(TestCase):
             'request': self.request
         }
         value = format_currency(ctx, 'aed', 1)
-        self.assertEqual(value, 'د.إ1')
+        self.assertEqual(value, 'د.إ.‏ 1')
 
     def test_get_localised_symbol_usd_en_us(self):
         self.request.LANGUAGE_CODE = 'en-US'


### PR DESCRIPTION
As [suggested by @TheoChevalier here](https://github.com/mozilla/donate-wagtail/issues/140#issuecomment-518725204), this PR replaces py-moneyed with the more robust and well-maintained babel library for currency formatting.

Note that babel has a limitation, which is that it isn't possible to tell its `format_currency` utility to ignore decimals for integer values (unless we provide custom formats for all currencies), so I have had to do some manipulation to achieve that. I _think_ this will work for all currencies, but it is possible that there are edge cases that we may run into.

@TheoChevalier would be grateful for your review on this.