### PR TITLE
Additions to data sent to basket and Braintree custom fields

### DIFF
--- a/donate/core/factory/core_pages.py
+++ b/donate/core/factory/core_pages.py
@@ -17,6 +17,8 @@ class LandingPageFactory(PageFactory):
         model = LandingPage
 
     title = Faker('text', max_nb_chars=140)
+    campaign_id = Faker('text', max_nb_chars=140)
+    project = 'mozillafoundation'
     intro = Faker('paragraph', nb_sentences=5, variable_nb_sentences=True)
     featured_image = SubFactory(ImageFactory)
 

--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -67,7 +67,14 @@ class DonationPage(Page):
             'currencies': self.currencies,
             'initial_currency_info': self.currencies[initial_currency],
             'braintree_params': settings.BRAINTREE_PARAMS,
-            'braintree_form': BraintreePaypalPaymentForm(initial={'source_page_id': self.pk}),
+            'braintree_form': BraintreePaypalPaymentForm(
+                initial={
+                    'source_page_id': self.pk,
+                    'landing_url': request.build_absolute_uri(),
+                    'project': self.project,
+                    'campaign_id': self.campaign_id,
+                }
+            ),
             'currency_form': CurrencyForm(initial={'currency': initial_currency}),
         })
         return ctx

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -18,7 +18,13 @@ class BraintreePaymentForm(forms.Form):
     amount = forms.DecimalField(min_value=0.01, decimal_places=2, widget=forms.HiddenInput)
 
 
-class BraintreeCardPaymentForm(BraintreePaymentForm):
+class CampaignFormMixin(forms.Form):
+    landing_url = forms.URLField(required=False, widget=forms.HiddenInput)
+    project = forms.CharField(widget=forms.HiddenInput)
+    campaign_id = forms.CharField(required=False, widget=forms.HiddenInput)
+
+
+class BraintreeCardPaymentForm(CampaignFormMixin, BraintreePaymentForm):
     # max_length on all the fields here is to comply with Braintree validation requirements.
     first_name = forms.CharField(label=_('First name'), max_length=255)
     last_name = forms.CharField(label=_('Last name'), max_length=255)
@@ -29,7 +35,7 @@ class BraintreeCardPaymentForm(BraintreePaymentForm):
     country = CountryField().formfield(initial='US')
 
 
-class BraintreePaypalPaymentForm(BraintreePaymentForm):
+class BraintreePaypalPaymentForm(CampaignFormMixin, BraintreePaymentForm):
     frequency = forms.ChoiceField(choices=constants.FREQUENCY_CHOICES, widget=forms.HiddenInput)
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES, widget=forms.HiddenInput)
     source_page_id = forms.IntegerField(widget=forms.HiddenInput)

--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -54,9 +54,9 @@ def send_transaction_to_basket(data):
         'recurring': data['payment_frequency'] == constants.FREQUENCY_MONTHLY,
         'service': data['payment_method'],
         'transaction_id': data['transaction_id'],
-        'project': 'mozillafoundation',   # TODO switch based on campaign
+        'project': data['project'],
         'last_4': data.get('last_4', None),
-        'donation_url': '',   # TODO obtain campaign URL
+        'donation_url': data['landing_url'],
         'locale': data['locale'],
         'conversion_amount': data.get('settlement_amount', None),
     }

--- a/donate/payments/tests/test_tasks.py
+++ b/donate/payments/tests/test_tasks.py
@@ -53,6 +53,7 @@ class BasketTransactionTestCase(TestCase):
             'payment_frequency': 'single',
             'payment_method': 'card',
             'transaction_id': 'transaction-1',
+            'landing_url': 'http://localhost',
             'project': 'mozillafoundation',
             'last_4': '1234',
             'locale': 'en-US',
@@ -71,7 +72,7 @@ class BasketTransactionTestCase(TestCase):
             'transaction_id': 'transaction-1',
             'project': 'mozillafoundation',
             'last_4': '1234',
-            'donation_url': '',
+            'donation_url': 'http://localhost',
             'locale': 'en-US',
             'conversion_amount': Decimal(10),
         }

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -1,4 +1,4 @@
-{% load i18n form_tags util_tags %}
+{% load i18n util_tags %}
 <div class="donate-form__content" id="js-donate-form" data-locale="{% get_locale %}">
     <div class="donate-form__tabs tabs js-tabs">
         <form class="donate-form__tab-options tabs__container" role="tablist">
@@ -34,7 +34,7 @@
                         <input type="radio" class="donation-amount__radio" name="amount" value="other" id="one-time-amount-other" autocomplete="off" data-other-amount-radio="">
                         <label for="one-time-amount-other" class="donation-amount__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                         <label for="one-time-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
-                        <input type="text" class="donation-amount__input" name="one-time-amount-other-input" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" data-other-amount="">
+                        <input type="text" class="donation-amount__input" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" data-other-amount="">
                     </div>
                 </div>
                 <input type="hidden" class="one-time-amount__total">
@@ -137,11 +137,9 @@
     <div id="payments__braintree-errors-paypal" class="payments__braintree-error" hidden></div>
     <form id="payments__braintree-form" method="post" action="{% url 'payments:paypal' %}" hidden>
         {% csrf_token %}
-        {% render_form_field braintree_form.braintree_nonce %}
-        {% render_form_field braintree_form.amount %}
-        {% render_form_field braintree_form.frequency %}
-        {% render_form_field braintree_form.currency %}
-        {% render_form_field braintree_form.source_page_id %}
+        {% for field in braintree_form.hidden_fields %}
+            {{ field }}
+        {% endfor %}
     </form>
 
     <footer class="donate-form__footer">

--- a/donate/templates/payment/card.html
+++ b/donate/templates/payment/card.html
@@ -69,7 +69,6 @@
                                 </div>
                             {% endif %}
 
-                            {% render_form_field form.amount %}
                             {% render_form_field form.email %}
                             {% render_form_field form.first_name %}
                             {% render_form_field form.last_name %}
@@ -80,6 +79,9 @@
                             </div>
                             {% render_form_field form.country %}
 
+                            {% for field in form.hidden_fields %}
+                                {{ field }}
+                            {% endfor %}
                         </div>
 
                         <div class="form__section">
@@ -96,7 +98,6 @@
                                         </div>
                                     </div>
                                 </header>
-                                {% render_form_field form.braintree_nonce %}
                             </div>
 
                             <div id="payments__braintree-errors-card" hidden></div>


### PR DESCRIPTION
This PR adds logic to pass some additional data to Basket and Braintree custom fields:

- Landing page URL and project identifier to basket
- Campaign ID and project identifier to Braintree

I ended up passing this data through the original forms, even though campaign ID and project ID could be obtained from the source page. The reason for this is that this information is required, and so we don't want to rely on the source page being available after the user has started a payment flow.

@nicklee FYI I have removed the `name` attribute from the `one-time-amount-other-input`, because if present this pollutes the GET params on the next step. Lighthouse will complain but I think we'll just have to ignore that.
