### PR TITLE
Refactor currency detection logic to use only user locale.

### DIFF
--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -50,8 +50,8 @@ class DonationPage(Page):
         # Query argument takes first preference
         if request.GET.get('currency') in constants.CURRENCIES:
             return request.GET['currency']
-        # Otherwise sniff based on browser language
-        return get_default_currency(request.META.get('HTTP_ACCEPT_LANGUAGE', ''))
+        # Otherwise use the language code determined by Django
+        return get_default_currency(getattr(request, 'LANGUAGE_CODE', ''))
 
     def serve(self, request, *args, **kwargs):
         response = super().serve(request, *args, **kwargs)

--- a/donate/core/tests/test_models.py
+++ b/donate/core/tests/test_models.py
@@ -18,11 +18,12 @@ class DonationPageTestCase(TestCase):
             'gbp'
         )
 
-    def test_get_initial_currency_uses_header(self):
-        request = RequestFactory().get('/', HTTP_ACCEPT_LANGUAGE='es-CL;q=0.9')
+    def test_get_initial_currency_uses_locale(self):
+        request = RequestFactory().get('/')
+        request.LANGUAGE_CODE = 'es-mx'
         self.assertEqual(
             DonationPage().get_initial_currency(request),
-            'clp'
+            'mxn'
         )
 
     def test_serve_sets_subscribed_cookie(self):

--- a/donate/payments/tests/test_utils.py
+++ b/donate/payments/tests/test_utils.py
@@ -21,28 +21,11 @@ class UtilsTestCase(TestCase):
             'amount': '50'
         })
 
-    def test_get_default_currency_uses_map(self):
-        self.assertEqual(
-            get_default_currency('en-AU;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5'),
-            'aud'
-        )
-        self.assertEqual(
-            get_default_currency('en-CA;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5'),
-            'cad'
-        )
-
-    def test_get_default_currency_next_language_pre(self):
-        # First preference is a bogus language. Second one is korean.
-        self.assertEqual(
-            get_default_currency('fo-FO;q=0.9, ko;q=0.8'),
-            'krw'
-        )
+    def test_get_default_currency_matches_exact_locale(self):
+        self.assertEqual(get_default_currency('nb-no'), 'nok')
 
     def test_get_default_currency_falls_back_to_base_language(self):
-        self.assertEqual(
-            get_default_currency('es-GG;q=0.9'),
-            'eur'
-        )
+        self.assertEqual(get_default_currency('es-GG'), 'eur')
 
     def test_get_default_currency_fallback_to_usd(self):
         self.assertEqual(get_default_currency(''), 'usd')

--- a/donate/payments/utils.py
+++ b/donate/payments/utils.py
@@ -1,8 +1,6 @@
 from functools import lru_cache
 from decimal import Decimal
 
-from django.utils.translation.trans_real import parse_accept_lang_header
-
 from .constants import CURRENCIES, LOCALE_CURRENCY_MAP
 
 
@@ -18,22 +16,17 @@ def get_currency_info(currency):
 
 
 @lru_cache(maxsize=1000)
-def get_default_currency(language_header):
-    """
-    Parse a HTTP Accept-Language header and return the best match for default
-    currency for the user's preferred language.
-    """
-    for lang, p in parse_accept_lang_header(language_header):
+def get_default_currency(lang):
+    """Return the best match for default currency for the user's locale."""
+    try:
+        return LOCALE_CURRENCY_MAP[lang]
+    except KeyError:
+        # Strip the region and attempt to find a currency that matches the base language
+        code, _, country = lang.partition('-')
         try:
-            return LOCALE_CURRENCY_MAP[lang]
+            return LOCALE_CURRENCY_MAP[code]
         except KeyError:
-            # If the language has a region, strip the region and see if we find a match
-            if '-' in lang:
-                base_lang = lang.split('-')[0]
-                try:
-                    return LOCALE_CURRENCY_MAP[base_lang]
-                except KeyError:
-                    pass
+            pass
 
     return 'usd'
 


### PR DESCRIPTION
Closes #166 - refactor currency detection to rely only on the locale determined by Django (and not the 'Accept-Language` header).

cc @TheoChevalier