### PR TITLE
Wrap data sent to SQS in a 'data' key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,22 +101,26 @@ For this project, we're only using the `donation` event type.
 Example of a donation message sent to Basket, via SQS:
 
 ```
-{ event_type: 'donation',
-  last_name: 'alex',
-  email: 'alex@alex.org',
-  donation_amount: 50,
-  currency: 'usd',
-  created: 1563801762,
-  recurring: false,
-  service: 'stripe',
-  transaction_id: 'ch_1Ez1TSG8Mmx3htnxyShib70n',
-  project: 'mozillafoundation',
-  last_4: '4242',
-  donation_url: 'http://localhost:3000/en-US/',
-  locale: 'en-US',
-  conversion_amount: 50,
-  net_amount: 48.6,
-  transaction_fee: 1.4 }
+{
+    'data': {
+        'event_type': 'donation',
+        'last_name': 'alex',
+        'email': 'alex@alex.org',
+        'donation_amount': 50,
+        'currency': 'usd',
+        'created': 1563801762,
+        'recurring': false,
+        'service': 'paypal',
+        'transaction_id': 'ch_1Ez1TSG8Mmx3htnxyShib70n',
+        'project': 'mozillafoundation',
+        'last_4': '4242',
+        'donation_url': 'http://localhost:3000/en-US/',
+        'locale': 'en-US',
+        'conversion_amount': 50,
+        'net_amount': 48.6,
+        'transaction_fee': 1.4
+    }
+}
 ```
 
 - `event_type`: Basket event type. Should be donation,

--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -44,20 +44,22 @@ def send_transaction_to_basket(data):
         return
 
     payload = {
-        'event_type': 'donation',
-        'last_name': data['last_name'],
-        'email': data['email'],
-        'donation_amount': data['amount'],
-        'currency': data['currency'],
-        'created': int(time.time()),
-        'recurring': data['payment_frequency'] == constants.FREQUENCY_MONTHLY,
-        'service': data['payment_method'],
-        'transaction_id': data['transaction_id'],
-        'project': data['project'],
-        'last_4': data.get('last_4', None),
-        'donation_url': data['landing_url'],
-        'locale': data['locale'],
-        'conversion_amount': data.get('settlement_amount', None),
+        'data': {
+            'event_type': 'donation',
+            'last_name': data['last_name'],
+            'email': data['email'],
+            'donation_amount': data['amount'],
+            'currency': data['currency'],
+            'created': int(time.time()),
+            'recurring': data['payment_frequency'] == constants.FREQUENCY_MONTHLY,
+            'service': data['payment_method'],
+            'transaction_id': data['transaction_id'],
+            'project': data['project'],
+            'last_4': data.get('last_4', None),
+            'donation_url': data['landing_url'],
+            'locale': data['locale'],
+            'conversion_amount': data.get('settlement_amount', None),
+        }
     }
 
     client.send_message(

--- a/donate/payments/tests/test_tasks.py
+++ b/donate/payments/tests/test_tasks.py
@@ -61,20 +61,22 @@ class BasketTransactionTestCase(TestCase):
         }
 
         self.sample_payload = {
-            'event_type': 'donation',
-            'last_name': 'Bob',
-            'email': 'test@example.com',
-            'donation_amount': Decimal(10),
-            'currency': 'usd',
-            'created': 1565222400,
-            'recurring': False,
-            'service': 'card',
-            'transaction_id': 'transaction-1',
-            'project': 'mozillafoundation',
-            'last_4': '1234',
-            'donation_url': 'http://localhost',
-            'locale': 'en-US',
-            'conversion_amount': Decimal(10),
+            'data': {
+                'event_type': 'donation',
+                'last_name': 'Bob',
+                'email': 'test@example.com',
+                'donation_amount': Decimal(10),
+                'currency': 'usd',
+                'created': 1565222400,
+                'recurring': False,
+                'service': 'card',
+                'transaction_id': 'transaction-1',
+                'project': 'mozillafoundation',
+                'last_4': '1234',
+                'donation_url': 'http://localhost',
+                'locale': 'en-US',
+                'conversion_amount': Decimal(10),
+            }
         }
 
     def test_sqs_payload(self):
@@ -92,6 +94,6 @@ class BasketTransactionTestCase(TestCase):
     def test_send_transaction_to_basket_monthly(self):
         self.sample_data['payment_frequency'] = 'monthly'
         self.sample_data['settlement_amount'] = None
-        self.sample_payload['recurring'] = True
-        self.sample_payload['conversion_amount'] = None
+        self.sample_payload['data']['recurring'] = True
+        self.sample_payload['data']['conversion_amount'] = None
         self.test_sqs_payload()


### PR DESCRIPTION
This PR addresses the changes requested in https://github.com/mozilla/donate-wagtail/issues/115#issuecomment-531376451. Specific commentary on those notes below:

> - Basket currently expects the payload to be wrapped in a data attribute, i.e. {"data":{...}}

Done.

> - Basket expects the payload to specify an event_type attribute, that it uses to invoke the appropriate worker method. 
> - The donation amount is being passed as amount, but basket is looking for donation_amount
> - Basket is looking for a service field, which previously was used to differentiate Stripe and Paypal donation.
> - Basket is expecting the payment frequency to be indicated via a recurring boolean attribute. 

All of these are already being set as desribed - just that there was no outer `data` key. So it should work now.
