### PR TITLE
Use minified versions of Paypal JS.

### DIFF
--- a/donate/templates/pages/core/landing_page.html
+++ b/donate/templates/pages/core/landing_page.html
@@ -62,7 +62,7 @@
 {% block extra_js %}
     {{ currencies|json_script:"currencies" }}
     {{ braintree_params|json_script:"payments__braintree-params" }}
-    <script src="https://www.paypalobjects.com/api/checkout.js" data-version-4></script>
+    <script src="https://www.paypalobjects.com/api/checkout.min.js" data-version-4></script>
     <script src="{% static '_js/payments-paypal.compiled.js' %}"></script>
     {% if recaptcha_site_key %}
     <script src="https://www.google.com/recaptcha/api.js?render=explicit" async defer></script>

--- a/donate/templates/payment/paypal_upsell.html
+++ b/donate/templates/payment/paypal_upsell.html
@@ -54,6 +54,6 @@
 
 {% block extra_js %}
     {{ braintree_params|json_script:"payments__braintree-params" }}
-    <script src="https://www.paypalobjects.com/api/checkout.js" data-version-4></script>
+    <script src="https://www.paypalobjects.com/api/checkout.min.js" data-version-4></script>
     <script src="{% static '_js/payments-paypal-upsell.compiled.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Refs #291.

We don't have control over the `button.js` script that is loaded by Paypal's own JS - presumably that will be minified when not using the Paypal sandbox.