### PR TITLE
Add webhook endpoint for Braintree, and processing for a couple of event types

### DIFF
--- a/donate/payments/braintree_webhooks.py
+++ b/donate/payments/braintree_webhooks.py
@@ -1,0 +1,25 @@
+from django import forms
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import FormView
+
+from .tasks import queue, process_webhook
+
+
+class WebhookForm(forms.Form):
+    bt_signature = forms.CharField()
+    bt_payload = forms.CharField()
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+class BraintreeWebhookView(FormView):
+    form_class = WebhookForm
+    http_method_names = ['post']
+
+    def form_valid(self, form):
+        queue.enqueue(process_webhook, form.cleaned_data)
+        return HttpResponse()
+
+    def form_invalid(self, form):
+        return HttpResponseBadRequest()

--- a/donate/payments/sqs.py
+++ b/donate/payments/sqs.py
@@ -1,6 +1,8 @@
 from functools import lru_cache
+import json
 
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 
 import boto3
 
@@ -14,3 +16,14 @@ def sqs_client():
             aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             region_name=settings.AWS_REGION
         )
+
+
+def send_to_sqs(payload):
+    client = sqs_client()
+    if client is None:
+        return
+
+    return client.send_message(
+        QueueUrl=settings.BASKET_SQS_QUEUE_URL,
+        MessageBody=json.dumps(payload, cls=DjangoJSONEncoder, sort_keys=True),
+    )

--- a/donate/payments/tests/test_braintree_webhooks.py
+++ b/donate/payments/tests/test_braintree_webhooks.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from ..braintree_webhooks import WebhookForm, BraintreeWebhookView
+from ..tasks import process_webhook
+
+
+class BraintreeWebhookViewTestCase(TestCase):
+
+    def test_form_valid_queues_task(self):
+        form = WebhookForm({
+            'bt_signature': 'signature',
+            'bt_payload': 'payload'
+        })
+        assert form.is_valid()
+        with mock.patch('donate.payments.braintree_webhooks.queue') as mock_queue:
+            response = BraintreeWebhookView().form_valid(form)
+
+        mock_queue.enqueue.assert_called_once_with(process_webhook, form.cleaned_data)
+        self.assertEqual(response.status_code, 200)
+
+    def test_form_invalid_returns_400(self):
+        form = WebhookForm({})
+        response = BraintreeWebhookView().form_invalid(form)
+        self.assertEqual(response.status_code, 400)

--- a/donate/payments/urls.py
+++ b/donate/payments/urls.py
@@ -36,5 +36,5 @@ urlpatterns = [
         'thank-you/',
         views.ThankYouView.as_view(),
         name='completed'
-    ),
+    )
 ]

--- a/donate/urls.py
+++ b/donate/urls.py
@@ -12,13 +12,15 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 from donate.payments import urls as payments_urls
+from donate.payments.braintree_webhooks import BraintreeWebhookView
 
 # Patterns not subject to i18n
 urlpatterns = [
     path('django-admin/', admin.site.urls),
     path('admin/', include(wagtailadmin_urls)),
     path('documents/', include(wagtaildocs_urls)),
-    path('django-rq/', include('django_rq.urls'))
+    path('django-rq/', include('django_rq.urls')),
+    path('braintree/webhook/', BraintreeWebhookView.as_view(), name='braintree_webhook'),
 ]
 
 urlpatterns += i18n_patterns(


### PR DESCRIPTION
Refs #216.

This PR adds a webhook endpoint that we can use to receive webhooks from Braintree, and the scaffolding to process these. I have added handling for a couple of events, but I think someone more familiar with what Basket is expecting in this regard will need to test/review/modify this.

We'll also need to configure some webhooks in the Braintree dashboard to test end to end.