### PR TITLE
Allow query argument driven override of preset donation amounts.

### DIFF
--- a/donate/core/tests/test_models.py
+++ b/donate/core/tests/test_models.py
@@ -129,3 +129,38 @@ class CampaignPageTestCase(TestCase):
             ctx['initial_currency_info']['presets']['monthly'],
             [Decimal(15), Decimal(12)]
         )
+
+    def test_get_initial_frequency_uses_arg(self):
+        request = RequestFactory().get('/?frequency=monthly')
+        self.assertEqual(
+            DonationPage().get_initial_frequency(request),
+            'monthly'
+        )
+
+    def test_get_initial_frequency_ignores_invalid_value(self):
+        request = RequestFactory().get('/?frequency=bogus')
+        self.assertEqual(
+            DonationPage().get_initial_frequency(request),
+            'single'
+        )
+
+    def test_get_initial_currency_info_uses_arg_and_sorts(self):
+        request = RequestFactory().get('/?presets=1,9,5,3')
+        self.assertEqual(
+            DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
+            [Decimal(9), Decimal(5), Decimal(3), Decimal(1)]
+        )
+
+    def test_get_initial_currency_info_skips_if_invalid_params_present(self):
+        request = RequestFactory().get('/?presets=1,9,5,3,foo')
+        self.assertEqual(
+            DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
+            DonationPage().currencies['usd']['presets']['single']
+        )
+
+    def test_get_initial_currency_info_limits_to_four_shoices(self):
+        request = RequestFactory().get('/?presets=1,9,5,3,7,3')
+        self.assertEqual(
+            DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
+            [Decimal(9), Decimal(7), Decimal(5), Decimal(3)]
+        )

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -7,18 +7,18 @@
         <form class="donate-form__tab-options tabs__container">
             <div class="tabs__option" role="presentation">
                 <label for="one-time" class="tabs__label tabs__item--selected js-tab-item" aria-controls="tab-panel-1" aria-selected="true" id="tab-1">
-                    <input type="radio" class="tabs__radio-option" name="donation_frequency" id="one-time" value="one-time" checked>
+                    <input type="radio" class="tabs__radio-option" name="donation_frequency" id="one-time" value="one-time" {% if initial_frequency == 'single' %}checked{% endif %}>
                     <span class="tabs__label-text">{% trans "ONE TIME" %}</span>
                 </label>
             </div>
             <div class="tabs__option" role="presentation">
                 <label for="monthly" class="tabs__label js-tab-item" aria-controls="tab-panel-2" id="tab-2">
-                    <input type="radio" class="tabs__radio-option" name="donation_frequency" id="monthly" value="monthly">
+                    <input type="radio" class="tabs__radio-option" name="donation_frequency" id="monthly" value="monthly" {% if initial_frequency == 'monthly' %}checked{% endif %}>
                     <span class="tabs__label-text">{% trans "MONTHLY" %}</span>
                 </label>
             </div>
         </form>
-        <div class="tabs__panel js-tab-panel" id="tab-panel-1" role="tabpanel" aria-labelledby="tab-1">
+        <div class="tabs__panel js-tab-panel {% if initial_frequency == 'monthly' %}tabs__panel--hidden{% endif %}" id="tab-panel-1" role="tabpanel" aria-labelledby="tab-1">
             <form method="GET" id="donate-form--single">
                 <input type="hidden" name="source_page_id" value="{{ page.pk }}">
                 <input type="hidden" name="currency" value="{{ initial_currency_info.code }}" class="js-form-currency">
@@ -78,7 +78,7 @@
 
             {% include "fragments/donate_form_disclaimer.html" with monthly=false %}
         </div>
-        <div class="js-tab-panel tabs__panel tabs__panel--hidden" id="tab-panel-2" role="tabpanel" aria-labelledby="tab-2">
+        <div class="js-tab-panel tabs__panel {% if initial_frequency == 'single' %}tabs__panel--hidden{% endif %}" id="tab-panel-2" role="tabpanel" aria-labelledby="tab-2">
             <form method="GET" id="donate-form--monthly">
                 <input type="hidden" name="source_page_id" value="{{ page.pk }}">
                 <input type="hidden" name="currency" value="{{ initial_currency_info.code }}" class="js-form-currency">


### PR DESCRIPTION
Closes #218.

@alanmoo grateful if you can test this on the review app and confirm that it works the way you want.

Some examples:

https://donate-wagtail-staging-pr-408.herokuapp.com/en-US/?presets=10,9,8,7
https://donate-wagtail-staging-pr-408.herokuapp.com/en-US/?presets=10,9,8,7&frequency=monthly
https://donate-wagtail-staging-pr-408.herokuapp.com/en-US/?presets=1,9,3,4 - the amounts get sorted descending
https://donate-wagtail-staging-pr-408.herokuapp.com/en-US/?presets=10,9,8,7,34,7,8 - limited to max 4 choices
 