### PR TITLE
Enforce minimum amounts on all amount forms.

### DIFF
--- a/donate/core/templatetags/util_tags.py
+++ b/donate/core/templatetags/util_tags.py
@@ -29,9 +29,9 @@ def get_locale(context):
     return to_known_locale(context['request'].LANGUAGE_CODE)
 
 
-@register.simple_tag(takes_context=True)
-def format_currency(context, currency_code, amount):
-    locale = to_known_locale(context['request'].LANGUAGE_CODE)
+@register.simple_tag()
+def format_currency(language_code, currency_code, amount):
+    locale = to_known_locale(language_code)
     locale_obj = Locale.parse(locale)
     pattern = locale_obj.currency_formats['standard'].pattern
 

--- a/donate/core/tests/test_templatetags.py
+++ b/donate/core/tests/test_templatetags.py
@@ -15,43 +15,23 @@ class UtilTagsTestCase(TestCase):
         self.assertEqual(to_known_locale('es-XL'), 'es')
 
     def test_format_currency_usd_en_us_integer(self):
-        self.request.LANGUAGE_CODE = 'en-US'
-        ctx = {
-            'request': self.request
-        }
-        value = format_currency(ctx, 'usd', 1)
+        value = format_currency('en-US', 'usd', 1)
         self.assertEqual(value, '$1')
 
     def test_format_currency_usd_en_us_decimal(self):
-        self.request.LANGUAGE_CODE = 'en-US'
-        ctx = {
-            'request': self.request
-        }
-        value = format_currency(ctx, 'usd', 1.5)
+        value = format_currency('en-US', 'usd', 1.5)
         self.assertEqual(value, '$1.50')
 
     def test_format_currency_usd_en_gb(self):
-        self.request.LANGUAGE_CODE = 'en-GB'
-        ctx = {
-            'request': self.request
-        }
-        value = format_currency(ctx, 'usd', 1)
+        value = format_currency('en-GB', 'usd', 1)
         self.assertEqual(value, 'US$1')
 
     def test_format_currency_aed_en_us(self):
-        self.request.LANGUAGE_CODE = 'en-US'
-        ctx = {
-            'request': self.request
-        }
-        value = format_currency(ctx, 'aed', 1)
+        value = format_currency('en-US', 'aed', 1)
         self.assertEqual(value, 'AED1')
 
     def test_format_currency_aed_ar(self):
-        self.request.LANGUAGE_CODE = 'ar'
-        ctx = {
-            'request': self.request
-        }
-        value = format_currency(ctx, 'aed', 1)
+        value = format_currency('ar', 'aed', 1)
         self.assertEqual(value, 'د.إ.‏ 1')
 
     def test_get_localised_symbol_usd_en_us(self):

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -2,14 +2,16 @@ from django import forms
 from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import pgettext_lazy
+from django.utils.translation import get_language, pgettext_lazy
 
 from django_countries.fields import CountryField
 
 from donate.core.utils import is_donation_page
+from donate.core.templatetags.util_tags import format_currency
 from donate.recaptcha.fields import ReCaptchaField
 
 from . import constants
+from .utils import get_currency_info
 
 
 # Global maximum amount value of 10 million, not currency-specific, intended
@@ -17,7 +19,34 @@ from . import constants
 MAX_AMOUNT_VALUE = 10000000
 
 
-class StartCardPaymentForm(forms.Form):
+class MinimumCurrencyAmountMixin():
+    """
+    Mixin for validating minimum amounts. Expects currency and amount fields
+    to be defined on the form. If a currency is supplied on initialization,
+    then this is used to set a `min` attribute on the amount field.
+    """
+
+    def __init__(self, *args, **kwargs):
+        currency = kwargs.pop('currency', None)
+        super().__init__(*args, **kwargs)
+        if currency:
+            currency_info = get_currency_info(currency)
+            self.fields['amount'].widget.attrs['min'] = currency_info['minAmount']
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get('amount') and cleaned_data.get('currency'):
+            currency_info = get_currency_info(cleaned_data['currency'])
+            min_amount = currency_info['minAmount']
+            if cleaned_data['amount'] < min_amount:
+                raise forms.ValidationError({
+                    'amount': _('Donations must be %(amount)s or more') % {'amount': format_currency(
+                        get_language(), cleaned_data['currency'], min_amount
+                    )}
+                })
+
+
+class StartCardPaymentForm(MinimumCurrencyAmountMixin, forms.Form):
     amount = forms.DecimalField(label=_('Amount'), min_value=0.01, max_value=MAX_AMOUNT_VALUE, decimal_places=2)
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES)
     source_page_id = forms.IntegerField(widget=forms.HiddenInput)
@@ -63,7 +92,7 @@ class BraintreeCardPaymentForm(CampaignFormMixin, BraintreePaymentForm):
         captcha = ReCaptchaField()
 
 
-class BraintreePaypalPaymentForm(CampaignFormMixin, BraintreePaymentForm):
+class BraintreePaypalPaymentForm(MinimumCurrencyAmountMixin, CampaignFormMixin, BraintreePaymentForm):
     frequency = forms.ChoiceField(choices=constants.FREQUENCY_CHOICES, widget=forms.HiddenInput)
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES, widget=forms.HiddenInput)
 
@@ -76,19 +105,16 @@ class CurrencyForm(forms.Form):
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES)
 
 
-class UpsellForm(forms.Form):
+class UpsellForm(MinimumCurrencyAmountMixin, forms.Form):
+    currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES, widget=forms.HiddenInput, disabled=True)
     amount = forms.DecimalField(
         label=_('Amount'), min_value=1, max_value=MAX_AMOUNT_VALUE, decimal_places=2,
         widget=forms.NumberInput(attrs={'step': 'any'})
     )
 
 
-class BraintreePaypalUpsellForm(BraintreePaymentForm):
-    currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES, widget=forms.HiddenInput)
-    amount = forms.DecimalField(
-        label=_('Amount'), min_value=1, max_value=MAX_AMOUNT_VALUE, decimal_places=2,
-        widget=forms.NumberInput(attrs={'step': 'any'})
-    )
+class BraintreePaypalUpsellForm(UpsellForm, BraintreePaymentForm):
+    pass
 
 
 class NewsletterSignupForm(forms.Form):

--- a/donate/payments/tests/test_forms.py
+++ b/donate/payments/tests/test_forms.py
@@ -1,0 +1,22 @@
+from django import forms
+from django.test import TestCase
+
+from .. import constants
+from ..forms import MinimumCurrencyAmountMixin
+
+
+class MinimumCurrencyTestForm(MinimumCurrencyAmountMixin, forms.Form):
+    amount = forms.DecimalField()
+    currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES)
+
+
+class MinimumCurrencyAmountMixinTestCase(TestCase):
+
+    def test_init_sets_min_attr_if_currency_supplied(self):
+        form = MinimumCurrencyTestForm(currency='usd')
+        self.assertEqual(form.fields['amount'].widget.attrs['min'], 2)
+
+    def test_clean_validates_minimum_amount(self):
+        form = MinimumCurrencyTestForm({'amount': 1, 'currency': 'usd'})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {'amount': ['Donations must be $2 or more']})

--- a/donate/payments/tests/test_views.py
+++ b/donate/payments/tests/test_views.py
@@ -591,7 +591,7 @@ class CardUpsellViewTestCase(TestCase):
 
     @freeze_time('2019-07-26')
     def test_subscription_data_submitted_to_braintree(self):
-        form = UpsellForm({'amount': Decimal(15)})
+        form = UpsellForm({'amount': Decimal(15), 'currency': 'usd'}, initial={'currency': 'usd'})
         assert form.is_valid()
 
         with mock.patch('donate.payments.views.gateway', autospec=True) as mock_gateway:
@@ -606,8 +606,9 @@ class CardUpsellViewTestCase(TestCase):
         })
 
     def test_failed_customer_creation_calls_error_processor(self):
-        form = UpsellForm({'amount': Decimal(15)})
+        form = UpsellForm({'amount': Decimal(15), 'currency': 'usd'}, initial={'currency': 'usd'})
         assert form.is_valid()
+        self.view.currency = 'usd'
 
         with mock.patch('donate.payments.views.gateway', autospec=True) as mock_gateway:
             mock_gateway.subscription.create.return_value.is_success = False
@@ -617,7 +618,7 @@ class CardUpsellViewTestCase(TestCase):
         self.assertTrue(response.status_code, 200)
 
     def test_get_transaction_details_for_session(self):
-        form = UpsellForm({'amount': Decimal(17)})
+        form = UpsellForm({'amount': Decimal(17), 'currency': 'usd'}, initial={'currency': 'usd'})
         assert form.is_valid()
 
         mock_result = MockBraintreeSubscriptionResult()
@@ -680,8 +681,9 @@ class PaypalUpsellViewTestCase(TestCase):
     def test_subscription_data_submitted_to_braintree(self):
         form = BraintreePaypalUpsellForm({
             'amount': Decimal(15), 'braintree_nonce': 'hello-braintree', 'currency': 'usd'
-        })
+        }, initial={'currency': 'usd'})
         assert form.is_valid()
+        self.view.currency = 'usd'
 
         with mock.patch('donate.payments.views.gateway') as mock_gateway:
             mock_gateway.customer.create.return_value.is_success = True
@@ -699,8 +701,9 @@ class PaypalUpsellViewTestCase(TestCase):
     def test_failed_customer_creation_calls_error_processor(self):
         form = BraintreePaypalUpsellForm({
             'amount': Decimal(15), 'braintree_nonce': 'hello-braintree', 'currency': 'usd'
-        })
+        }, initial={'currency': 'usd'})
         assert form.is_valid()
+        self.view.currency = 'usd'
 
         with mock.patch('donate.payments.views.gateway') as mock_gateway:
             mock_gateway.subscription.create.return_value.is_success = False
@@ -712,7 +715,7 @@ class PaypalUpsellViewTestCase(TestCase):
     def test_get_transaction_details_for_session(self):
         form = BraintreePaypalUpsellForm({
             'amount': Decimal(17), 'braintree_nonce': 'hello-braintree', 'currency': 'usd'
-        })
+        }, initial={'currency': 'usd'})
         assert form.is_valid()
 
         self.view.currency = 'usd'

--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -424,6 +424,7 @@ class CardUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView):
         self.suggested_upgrade = get_suggested_monthly_upgrade(
             last_transaction['currency'], last_transaction['amount']
         )
+        self.currency = last_transaction['currency']
         if self.suggested_upgrade is None:
             return HttpResponseRedirect(self.get_success_url())
 
@@ -431,19 +432,23 @@ class CardUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView):
 
     def get_initial(self):
         return {
-            'amount': self.suggested_upgrade
+            'amount': self.suggested_upgrade,
+            'currency': self.currency,
         }
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['currency'] = self.currency
+        return kwargs
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx['currency_info'] = get_currency_info(
-            self.request.session['completed_transaction_details']['currency']
-        )
+        ctx['currency_info'] = get_currency_info(self.currency)
         return ctx
 
     def form_valid(self, form, send_data_to_basket=True):
         payment_method_token = self.request.session['completed_transaction_details']['payment_method_token']
-        currency = self.request.session['completed_transaction_details']['currency']
+        currency = form.cleaned_data['currency']
 
         # Create a subcription against the payment method
         start_date = now().date() + relativedelta(months=1)     # Start one month from today
@@ -504,6 +509,7 @@ class PaypalUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView
         self.suggested_upgrade = get_suggested_monthly_upgrade(
             last_transaction['currency'], last_transaction['amount']
         )
+        self.currency = self.request.session['completed_transaction_details']['currency']
         if self.suggested_upgrade is None:
             return HttpResponseRedirect(self.get_success_url())
 
@@ -511,13 +517,16 @@ class PaypalUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView
 
     def get_initial(self):
         return {
-            'currency': self.request.session['completed_transaction_details']['currency'],
+            'currency': self.currency,
             'amount': self.suggested_upgrade
         }
 
-    def form_valid(self, form, send_data_to_basket=True):
-        self.currency = form.cleaned_data['currency']
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['currency'] = self.currency
+        return kwargs
 
+    def form_valid(self, form, send_data_to_basket=True):
         # Create a customer and payment method for this customer
         result = gateway.customer.create({
             'payment_method_nonce': form.cleaned_data['braintree_nonce'],
@@ -575,9 +584,7 @@ class PaypalUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView
         ctx = super().get_context_data(**kwargs)
         ctx.update({
             'braintree_params': settings.BRAINTREE_PARAMS,
-            'currency_info': get_currency_info(
-                self.request.session['completed_transaction_details']['currency']
-            ),
+            'currency_info': get_currency_info(self.currency),
         })
         return ctx
 

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -28,7 +28,7 @@
                     <div class="donation-amount">
                         <input type="radio" class="donation-amount__radio" name="amount" value="{{ amount }}" id="one-time-amount-{{ forloop.counter0 }}" autocomplete="off" {% if forloop.first %}checked{% endif %}>
                         <label for="one-time-amount-{{ forloop.counter0 }}" class="donation-amount__label">
-                            {% format_currency initial_currency_info.code amount %}
+                            {% format_currency request.LANGUAGE_CODE initial_currency_info.code amount %}
                         </label>
                     </div>
                     {% endfor %}
@@ -37,7 +37,7 @@
                         <input type="radio" class="donation-amount__radio" name="amount" value="other" id="one-time-amount-other" autocomplete="off" data-other-amount-radio="">
                         <label for="one-time-amount-other" class="donation-amount__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                         <label for="one-time-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
-                        <input type="number" class="donation-amount__input" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" min="1" max="10000000" data-other-amount="">
+                        <input type="number" class="donation-amount__input" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" min="{{ initial_currency_info.minAmount }}" max="10000000" data-other-amount="">
                     </div>
                 </div>
                 <input type="hidden" class="one-time-amount__total">
@@ -88,7 +88,7 @@
                     <div class="donation-amount">
                         <input type="radio" class="donation-amount__radio" name="amount" value="{{ amount }}" id="monthly-amount-{{ forloop.counter0 }}" autocomplete="off" {% if forloop.first %}checked{% endif %}>
                         <label for="monthly-amount-{{ forloop.counter0 }}" class="donation-amount__label">
-                            {% format_currency initial_currency_info.code amount %} <span>{% trans "per month" %}</span>
+                            {% format_currency request.LANGUAGE_CODE initial_currency_info.code amount %} <span>{% trans "per month" %}</span>
                         </label>
                     </div>
                     {% endfor %}
@@ -97,7 +97,7 @@
                         <input type="radio" class="donation-amount__radio" name="amount" value="other" id="monthly-amount-other" autocomplete="off" data-other-amount-radio="">
                         <label for="monthly-amount-other" class="donation-amount__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                         <label for="monthly-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
-                        <input type="number" class="donation-amount__input" name="monthly-amount-other-input" id="monthly-amount-other-input" min="1" max="10000000" placeholder="{% trans 'Other amount' %}" data-other-amount="">
+                        <input type="number" class="donation-amount__input" name="monthly-amount-other-input" id="monthly-amount-other-input" min="{{ initial_currency_info.minAmount }}" max="10000000" placeholder="{% trans 'Other amount' %}" data-other-amount="">
                     </div>
                 </div>
                 <input type="hidden" class="monthly-amount__total">

--- a/donate/templates/payment/card.html
+++ b/donate/templates/payment/card.html
@@ -15,7 +15,7 @@
                 <div class="notification notification--neutral">
                     <div class="notification__container">
                         <div class="notification__message">
-                            {% format_currency currency_info.code form.amount.value as formatted_amount %}
+                            {% format_currency request.LANGUAGE_CODE currency_info.code form.amount.value as formatted_amount %}
                             {% if payment_frequency == 'monthly' %}
                                 {% blocktrans with formatted_amount=formatted_amount span_class='js-donation-value' %}You are donating <span class="{{ span_class }}">{{ formatted_amount }}</span> per month{% endblocktrans %}
                             {% else %}
@@ -33,7 +33,7 @@
                         <div class="donation-update__form-item form-item">
                             <label class="donation-update__label form-item__label" for="donation-update">{% trans "Donation Amount" %}</label>
                             <div class="donation-update__currency-symbol">{% get_localized_currency_symbol currency_info.code %}</div>
-                            <input class="donation-update__input form-item__input" id="js-update-donation-value" type="number" name="donation-update" value="{{ form.amount.value }}" step="1" min="1" max="10000000" required>
+                            <input class="donation-update__input form-item__input" id="js-update-donation-value" type="number" name="donation-update" value="{{ form.amount.value }}" step="1" min="{{ currency_info.minAmount }}" max="10000000" required>
                         </div>
                         <div class="form-item">
                             <button class="donation-update__action button button--primary button--large" id="js-update-button">{% trans 'Confirm' %}</button>
@@ -136,7 +136,7 @@
                                     <use xlink:href="#padlock"></use>
                                 </svg>
                                 <div class="button__label">
-                                    {% format_currency currency_info.code form.amount.value as formatted_amount %}
+                                    {% format_currency request.LANGUAGE_CODE currency_info.code form.amount.value as formatted_amount %}
                                     {% blocktrans with formatted_amount=formatted_amount span_class='button__value js-donation-value' %}Donate <span class="{{ span_class }}">{{ formatted_amount }}</span>{% endblocktrans %}
                                 </div>
                             </button>

--- a/donate/templates/payment/card_upsell.html
+++ b/donate/templates/payment/card_upsell.html
@@ -36,6 +36,10 @@
                             {% render_form_field form.amount %}
                         </div>
 
+                        {% for field in form.hidden_fields %}
+                            {{ field }}
+                        {% endfor %}
+
                         <p><small>{% trans "I authorize Mozilla Foundation to charge my card in the amount shown above and to continue doing so each month until I cancel." %}</small></p>
                     </div>
 


### PR DESCRIPTION
Refs #438. 

There is one issue here which I cannot find a way around. PayPal [doesn't provide any way for us to do validation](https://github.com/paypal/paypal-checkout-components/issues/139) before their flow is initialised. This means that if you enter an "other amount" that is too low and immediately hit the PayPal button, the flow will start and we have no way to stop it. I have added browser-level validation which will *show* an error on the field, but it will not stop the PayPal modal from loading.

The best workaround I have been able to find is to pass invalid data to PayPal, so that it returns an error.