### PR TITLE
Refactor sending of subscription transactions to Basket

### DIFF
--- a/donate/payments/tests/test_views.py
+++ b/donate/payments/tests/test_views.py
@@ -359,7 +359,7 @@ class MonthlyCardPaymentViewTestCase(CardPaymentViewTestCase):
             mock_create_customer.return_value.is_success = True
             mock_create_customer.return_value.customer = MockBraintreeCustomer()
             with mock.patch('donate.payments.views.gateway', autospec=True) as mock_gateway:
-                self.view.form_valid(form, send_data_to_basket=False)
+                self.view.form_valid(form)
 
         mock_gateway.subscription.create.assert_called_once_with({
             'plan_id': 'usd-plan',
@@ -595,7 +595,7 @@ class CardUpsellViewTestCase(TestCase):
         assert form.is_valid()
 
         with mock.patch('donate.payments.views.gateway', autospec=True) as mock_gateway:
-            self.view.form_valid(form, send_data_to_basket=False)
+            self.view.form_valid(form)
 
         mock_gateway.subscription.create.assert_called_once_with({
             'plan_id': 'usd-plan',
@@ -686,7 +686,7 @@ class PaypalUpsellViewTestCase(TestCase):
         with mock.patch('donate.payments.views.gateway') as mock_gateway:
             mock_gateway.customer.create.return_value.is_success = True
             mock_gateway.customer.create.return_value.customer = MockBraintreeCustomer()
-            self.view.form_valid(form, send_data_to_basket=False)
+            self.view.form_valid(form)
 
         mock_gateway.subscription.create.assert_called_once_with({
             'plan_id': 'usd-plan',

--- a/donate/payments/tests/test_views.py
+++ b/donate/payments/tests/test_views.py
@@ -249,7 +249,11 @@ class CardPaymentViewTestCase(TestCase):
         form = BraintreeCardPaymentForm(self.form_data)
         assert form.is_valid()
         custom_fields = self.view.get_custom_fields(form)
-        self.assertEqual(custom_fields, {'campaign_id': '', 'project': 'mozillafoundation'})
+        self.assertEqual(custom_fields, {
+            'campaign_id': '',
+            'project': 'mozillafoundation',
+            'locale': 'en-US',
+        })
 
     def test_get_address_info(self):
         info = self.view.get_address_info(self.form_data)
@@ -272,7 +276,7 @@ class CardPaymentViewTestCase(TestCase):
             'last_name': self.form_data['last_name'],
             'email': self.form_data['email'],
             'payment_method_nonce': 'hello-braintree',
-            'custom_fields': {'project': 'mozillafoundation', 'campaign_id': ''},
+            'custom_fields': {'project': 'mozillafoundation', 'campaign_id': '', 'locale': 'en-US'},
             'credit_card': {
                 'billing_address': {
                     'street_address': self.form_data['address_line_1'],
@@ -441,7 +445,7 @@ class PaypalPaymentViewTestCase(TestCase):
 
         mock_gateway.transaction.sale.assert_called_once_with({
             'amount': 10,
-            'custom_fields': {'project': 'mozillafoundation', 'campaign_id': ''},
+            'custom_fields': {'project': 'mozillafoundation', 'campaign_id': '', 'locale': 'en-US'},
             'payment_method_nonce': 'hello-braintree',
             'merchant_account_id': 'usd-ac',
             'options': {'submit_for_settlement': True}
@@ -463,7 +467,7 @@ class PaypalPaymentViewTestCase(TestCase):
 
         mock_gateway.customer.create.assert_called_once_with({
             'payment_method_nonce': 'hello-braintree',
-            'custom_fields': {'project': 'mozillafoundation', 'campaign_id': ''},
+            'custom_fields': {'project': 'mozillafoundation', 'campaign_id': '', 'locale': 'en-US'},
         })
 
         mock_gateway.subscription.create.assert_called_once_with({

--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -32,6 +32,7 @@ class BraintreePaymentMixin:
         return {
             'project': self.request.session.get('project', 'mozillafoundation'),
             'campaign_id': self.request.session.get('campaign_id', ''),
+            'locale': self.request.LANGUAGE_CODE,
         }
 
     def get_merchant_account_id(self, currency):

--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -176,7 +176,7 @@ class CardPaymentView(BraintreePaymentMixin, FormView):
         if self.payment_frequency == constants.FREQUENCY_SINGLE:
             return self.process_single_transaction(form, send_data_to_basket=send_data_to_basket)
         else:
-            return self.process_monthly_transaction(form, send_data_to_basket=send_data_to_basket)
+            return self.process_monthly_transaction(form)
 
     def create_customer(self, form):
         result = gateway.customer.create({
@@ -234,7 +234,7 @@ class CardPaymentView(BraintreePaymentMixin, FormView):
             )
             return self.process_braintree_error_result(result, form)
 
-    def process_monthly_transaction(self, form, send_data_to_basket=True):
+    def process_monthly_transaction(self, form):
         # Create a customer and payment method for this customer
         result = self.create_customer(form)
 
@@ -257,7 +257,7 @@ class CardPaymentView(BraintreePaymentMixin, FormView):
                 form,
                 transaction_id=result.subscription.id,
                 last_4=payment_method.last_4,
-                send_data_to_basket=send_data_to_basket,
+                send_data_to_basket=False,
             )
         else:
             logger.error(
@@ -331,6 +331,7 @@ class PaypalPaymentView(BraintreePaymentMixin, FormView):
                 'payment_method_token': payment_method.token,
                 'price': form.cleaned_data['amount'],
             })
+            send_data_to_basket = False
 
         if result.is_success:
             return self.success(result, form, send_data_to_basket=send_data_to_basket, **success_kwargs)
@@ -441,7 +442,7 @@ class CardUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView):
         )
         return ctx
 
-    def form_valid(self, form, send_data_to_basket=True):
+    def form_valid(self, form):
         payment_method_token = self.request.session['completed_transaction_details']['payment_method_token']
         currency = self.request.session['completed_transaction_details']['currency']
 
@@ -456,7 +457,7 @@ class CardUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView):
         })
 
         if result.is_success:
-            return self.success(result, form, currency=currency, send_data_to_basket=send_data_to_basket)
+            return self.success(result, form, currency=currency, send_data_to_basket=False)
         else:
             logger.error(
                 'Failed to create Braintree subscription: {}'.format(result.message),
@@ -515,7 +516,7 @@ class PaypalUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView
             'amount': self.suggested_upgrade
         }
 
-    def form_valid(self, form, send_data_to_basket=True):
+    def form_valid(self, form):
         self.currency = form.cleaned_data['currency']
 
         # Create a customer and payment method for this customer
@@ -544,7 +545,7 @@ class PaypalUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView
         })
 
         if result.is_success:
-            return self.success(result, form, send_data_to_basket=send_data_to_basket)
+            return self.success(result, form, send_data_to_basket=False)
         else:
             logger.error(
                 'Failed Braintree transaction: {}'.format(result.message),


### PR DESCRIPTION
Fixes #216, fixes #459.

- Don't send subscription initialisation information to Basket.
- Add webhook processing for successful subscription charges.
- Pass `locale` to Braintree as a custom field.

The webhook will need a bit of testing as the Braintree provides limited testing data. In particular I don't know that custom fields that are stored against a customer when creating a subscription are then passed to the custom fields for each transaction (and if they aren't, I can't currently see how we get that data).