### PR TITLE
[Pontoon] Get the SSH key during the release step

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,9 +5,6 @@
   "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {
-      "url": "https://github.com/Osmose/heroku-buildpack-ssh"
-    },
-    {
       "url": "heroku/nodejs"
     },
     {

--- a/release-steps.sh
+++ b/release-steps.sh
@@ -2,3 +2,6 @@
 
 # Django Migrations
 python manage.py migrate --no-input
+
+# Configuring ssh key to be able to push content that needs to be translated with Pontoon to a certain repo (`WAGTAILLOCALIZE_PONTOON_GIT_URL` env variable).
+echo $SSH_KEY > /app/.ssh/id_rsa

--- a/release-steps.sh
+++ b/release-steps.sh
@@ -4,4 +4,5 @@
 python manage.py migrate --no-input
 
 # Configuring ssh key to be able to push content that needs to be translated with Pontoon to a certain repo (`WAGTAILLOCALIZE_PONTOON_GIT_URL` env variable).
+mkdir /app/.ssh/
 echo $SSH_KEY > /app/.ssh/id_rsa


### PR DESCRIPTION
We're using Heroku pipeline, which means that when an app is `promoted` to prod, [it's not rebuild](https://devcenter.heroku.com/articles/pipelines#design-considerations). The SSH buildback is never executed on prod: if you check the SSH key from `id_rsa` on prod, you will see that it's the one from staging.

I'm moving the `id_rsa` file creation to `release steps.sh`, which is always executed during the deployment process.