### PR TITLE
Set the rq.worker logger to DEBUG level

### DIFF
--- a/donate/settings.py
+++ b/donate/settings.py
@@ -447,8 +447,8 @@ LOGGING = {
             'level': 'ERROR'
         },
         'rq.worker': {
-            'handlers': ['info'],
-            'level': 'INFO',
+            'handlers': ['debug'],
+            'level': 'DEBUG',
         },
         'donate': {
             'handlers': ['info'],


### PR DESCRIPTION
Setting this logger to DEBUG will ensure it doesn't log on production where the `DJANGO_LOG_LEVEL` is set to `INFO`