### PR TITLE
Subclass whitenoise.storage.CompressedManifestStaticFilesStorage

### DIFF
--- a/donate/settings.py
+++ b/donate/settings.py
@@ -356,8 +356,8 @@ django.conf.locale.LANG_INFO['uk'] = {
     'name_local': 'Ukrainian',
 }
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 STATICFILES_DIRS = [app('frontend')]
+STATICFILES_STORAGE = 'donate.utility.staticfiles.NonStrictCompressedManifestStaticFilesStorage'
 STATIC_ROOT = root('static')
 STATIC_URL = '/static/'
 

--- a/donate/utility/staticfiles.py
+++ b/donate/utility/staticfiles.py
@@ -1,0 +1,5 @@
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+
+class NonStrictCompressedManifestStaticFilesStorage(CompressedManifestStaticFilesStorage):
+    manifest_strict = False


### PR DESCRIPTION
 ... so that manifest_strict can be set to False, allowing debug=False to work with S3 storage disabled.

For this to work, you must run collectstatic. `inv docker-manage "collectstatic --no-input"`