### PR TITLE
mkdir .ssh won't fail if directory already there

### DIFF
--- a/.profile
+++ b/.profile
@@ -8,7 +8,7 @@ if [ $USE_PONTOON ]; then
   echo "Generating SSH config"
   SSH_DIR=/app/.ssh
 
-  mkdir $SSH_DIR
+  mkdir -p $SSH_DIR
   chmod 700 $SSH_DIR
 
   # echo is messing with the newlines, using this instead:


### PR DESCRIPTION
Since the old setup for Pontoon is still on staging, we're promoting a slug that already has a `.ssh` dir.
Pass a `-p` to mkdir to prevent it from erroring in the future.