### PR TITLE
Add TargetDomainRedirectMiddleware

### DIFF
--- a/donate/settings.py
+++ b/donate/settings.py
@@ -38,6 +38,8 @@ env = environ.Env(
     RANDOM_SEED=(int, None),
     CSRF_COOKIE_SECURE=(bool, False),
     SESSION_COOKIE_SECURE=(bool, False),
+    DOMAIN_REDIRECT_MIDDLEWARE_ENABLED=(bool, False),
+    TARGET_DOMAINS=(list, []),
     # Braintree
     BRAINTREE_USE_SANDBOX=(bool, True),
     BRAINTREE_MERCHANT_ID=(str, ''),
@@ -95,6 +97,10 @@ HEROKU_APP_NAME = env('HEROKU_APP_NAME')
 if HEROKU_APP_NAME:
     ALLOWED_HOSTS.append(HEROKU_APP_NAME + '.herokuapp.com')
 
+# Force permanent redirects to the domains specified in TARGET_DOMAINS
+DOMAIN_REDIRECT_MIDDLEWARE_ENABLED = env('DOMAIN_REDIRECT_MIDDLEWARE_ENABLED')
+TARGET_DOMAINS = env('TARGET_DOMAINS')
+
 INSTALLED_APPS = [
     'donate.users',
     'donate.core',
@@ -132,7 +138,8 @@ INSTALLED_APPS = [
     'django.contrib.sitemaps',
 ]
 
-MIDDLEWARE = [
+MIDDLEWARE = list(filter(None, [
+    'donate.utility.middleware.TargetDomainRedirectMiddleware' if DOMAIN_REDIRECT_MIDDLEWARE_ENABLED else None,
     'django.middleware.gzip.GZipMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -145,7 +152,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'wagtail.core.middleware.SiteMiddleware',
     'csp.middleware.CSPMiddleware',
-]
+]))
 
 ROOT_URLCONF = 'donate.urls'
 

--- a/donate/settings.py
+++ b/donate/settings.py
@@ -97,7 +97,7 @@ HEROKU_APP_NAME = env('HEROKU_APP_NAME')
 if HEROKU_APP_NAME:
     ALLOWED_HOSTS.append(HEROKU_APP_NAME + '.herokuapp.com')
 
-# Force permanent redirects to the domains specified in TARGET_DOMAINS
+# Force redirects to the domains specified in TARGET_DOMAINS
 DOMAIN_REDIRECT_MIDDLEWARE_ENABLED = env('DOMAIN_REDIRECT_MIDDLEWARE_ENABLED')
 TARGET_DOMAINS = env('TARGET_DOMAINS')
 

--- a/donate/utility/middleware.py
+++ b/donate/utility/middleware.py
@@ -1,0 +1,29 @@
+from django.http.response import HttpResponseRedirectBase
+from django.conf import settings
+
+hostnames = settings.TARGET_DOMAINS
+
+
+class HttpResponseTemporaryRedirect(HttpResponseRedirectBase):
+    status_code = 307
+
+
+class TargetDomainRedirectMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request_host = request.META['HTTP_HOST']
+        protocol = 'https' if request.is_secure() else 'http'
+
+        if request_host in hostnames:
+            return self.get_response(request)
+
+        # Redirect to the primary domain (hostnames[0])
+        redirect_url = '{protocol}://{hostname}{path}'.format(
+            protocol=protocol,
+            hostname=hostnames[0],
+            path=request.get_full_path()
+        )
+
+        return HttpResponseTemporaryRedirect(redirect_url)


### PR DESCRIPTION
Adds the `DOMAIN_REDIRECT_MIDDLEWARE_ENABLED` and `TARGET_DOMAINS` settings. 

When enabled, Django will redirect requests with a HOST header that don't match the `TARGET_DOMAINS` list to the "primary" domain, i.e. `TARGET_DOMAINS[0]`