### PR TITLE
case sensitivity

### DIFF
--- a/donate/templates/fragments/donate_form_disclaimer.html
+++ b/donate/templates/fragments/donate_form_disclaimer.html
@@ -1,3 +1,3 @@
-{% extends "fragments/donate_Form_disclaimer_master.html" %}
+{% extends "fragments/donate_form_disclaimer_master.html" %}
 
 {# There are no overrides in this template, but alternative apps can template-overide this file (e.g. thunderbird) #}

--- a/donate/thunderbird/templates/fragments/donate_form_disclaimer.html
+++ b/donate/thunderbird/templates/fragments/donate_form_disclaimer.html
@@ -1,4 +1,4 @@
-{% extends "fragments/donate_Form_disclaimer_master.html" %}
+{% extends "fragments/donate_form_disclaimer_master.html" %}
 
 {% load i18n %}
 


### PR DESCRIPTION
Does not break on macos, due to filesystem case insensitivity. Definitely breaks on a well-configured linux/unix machine.