### PR TITLE
Fix issue in tasks.py

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -157,6 +157,7 @@ def docker_new_env(ctx):
         ctx.run("docker-compose down --volumes")
         print("* Building Docker images")
         ctx.run("docker-compose build --no-cache backend watch-static-files", **PLATFORM_ARG)
+        ctx.run("docker-compose build backend-worker", **PLATFORM_ARG)
         print("* Applying database migrations.")
         docker_migrate(ctx)
         print("* Creating fake data")


### PR DESCRIPTION
We need to make sure that `backend_worker` gets rebuild when we run a `inv docker-new-env` or it might be missing dependencies. We don't need `--no-cache` since it's the same image as the `backend` service.