### PR TITLE
Fix the Stripe charge webhook

### DIFF
--- a/donate/payments/stripe_webhooks.py
+++ b/donate/payments/stripe_webhooks.py
@@ -1,25 +1,27 @@
-from django import forms
+import json
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import FormView
+from django.views.generic import View
 
 from .tasks import queue, process_stripe_webhook
 
 
-class StripeWebhookForm(forms.Form):
-    data = forms.TextInput()
-
-
 @method_decorator(csrf_exempt, name='dispatch')
-class StripeWebhookView(FormView):
-    form_class = StripeWebhookForm
+class StripeWebhookView(View):
     http_method_names = ['post']
 
-    def form_valid(self, form):
-        signature = self.request.META['HTTP_STRIPE_SIGNATURE']
-        queue.enqueue(process_stripe_webhook, form.cleaned_data, signature=signature)
-        return HttpResponse()
+    def post(self, request):
+        signature = request.META['HTTP_STRIPE_SIGNATURE']
 
-    def form_invalid(self, form):
-        return HttpResponseBadRequest()
+        if not signature:
+            return HttpResponseBadRequest(reason='HTTP_STRIPE_SIGNATURE must be provided')
+
+        try:
+            payload = json.loads(request.body)
+        except json.JSONDecodeError:
+            return HttpResponseBadRequest(reason='Payload is not valid JSON')
+
+        queue.enqueue(process_stripe_webhook, payload, signature=signature)
+
+        return HttpResponse()


### PR DESCRIPTION
1. Don't use Form and FormView, since unlike BrainTree, Stripe webhook request bodies are not form encoded.
2. Fix various issues accessing the data about the charge, subscription, invoice, and metadata
3. Update tests for the change in data formatting introduced by the above changes.

Fixes #632

Testing locally is tricky, and requires a reverse-proxy so that you can configure Stripe in test mode to replay webhook events to your local instance of the site. I'd suggest reviewing the code for any glaring issues or omissions, then we can put the endpoint through some more testing in the staging environment.