### PR TITLE
django conf. optimization for shared inheritance

### DIFF
--- a/donate/settings/__init__.py
+++ b/donate/settings/__init__.py
@@ -2,14 +2,14 @@ from .environment import env
 from .base import Base
 from .braintree import Braintree
 from .database import Database
+from .development import Development, ThunderbirdDevelopment
+from .production import Production, ThunderbirdProduction
 from .redis import Redis
+from .review_app import ReviewApp
 from .secure import Secure
 from .sentry import Sentry
-from .testing import Testing
-from .development import Development, ThunderbirdDevelopment
-from .review_app import ReviewApp
 from .staging import Staging, ThunderbirdStaging
-from .production import Production, ThunderbirdProduction
+from .testing import Testing
 
 # Exported Django Configuration objects
 __all__ = [
@@ -17,15 +17,15 @@ __all__ = [
     'Base',
     'Braintree',
     'Database',
+    'Development',
+    'Production',
     'Redis',
+    'ReviewApp',
     'Secure',
     'Sentry',
-    'Testing',
-    'Development',
     'Staging',
-    'ReviewApp',
-    'Production',
+    'Testing',
     'ThunderbirdDevelopment',
-    'ThunderbirdStaging',
     'ThunderbirdProduction',
+    'ThunderbirdStaging',
 ]

--- a/donate/settings/development.py
+++ b/donate/settings/development.py
@@ -1,15 +1,9 @@
-from configurations import Configuration
 from .environment import env
-from .oidc import OIDC
-from .database import Database
-from .base import Base
-from .redis import Redis
-from .braintree import Braintree
-from .s3 import S3
+from .shared_settings import SharedSettings
 from .thunderbird import ThunderbirdOverrides
 
 
-class Development(Base, OIDC, Database, Redis, S3, Braintree, Configuration):
+class Development(SharedSettings):
     DEBUG = env('DEBUG')
     DJANGO_LOG_LEVEL = env('DJANGO_LOG_LEVEL')
 
@@ -40,7 +34,7 @@ class Development(Base, OIDC, Database, Redis, S3, Braintree, Configuration):
         super().post_setup()
 
 
-class ThunderbirdDevelopment(Development, ThunderbirdOverrides, Configuration):
+class ThunderbirdDevelopment(Development, ThunderbirdOverrides):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Development.INSTALLED_APPS
 
     @property

--- a/donate/settings/production.py
+++ b/donate/settings/production.py
@@ -1,17 +1,9 @@
-from configurations import Configuration
 from .environment import env
-from .base import Base
-from .secure import Secure
-from .oidc import OIDC
-from .database import Database
-from .redis import Redis
-from .s3 import S3
-from .braintree import Braintree
-from .sentry import Sentry
+from .shared_settings import SharedSettingsDeployment
 from .thunderbird import ThunderbirdOverrides
 
 
-class Production(Base, Secure, OIDC, Database, Redis, S3, Braintree, Sentry, Configuration):
+class Production(SharedSettingsDeployment):
     DEBUG = False
     SECRET_KEY = env('DJANGO_SECRET_KEY')
     BASKET_API_ROOT_URL = env('BASKET_API_ROOT_URL')
@@ -35,7 +27,7 @@ class Production(Base, Secure, OIDC, Database, Redis, S3, Braintree, Sentry, Con
         super().post_setup()
 
 
-class ThunderbirdProduction(Production, ThunderbirdOverrides, Configuration):
+class ThunderbirdProduction(Production, ThunderbirdOverrides):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Production.INSTALLED_APPS
 
     @property

--- a/donate/settings/shared_settings.py
+++ b/donate/settings/shared_settings.py
@@ -1,0 +1,36 @@
+from configurations import Configuration
+from .base import Base
+from .oidc import OIDC
+from .database import Database
+from .redis import Redis
+from .s3 import S3
+from .secure import Secure
+from .sentry import Sentry
+from .braintree import Braintree
+
+class SharedSettings(Base, OIDC, Database, Redis, S3, Braintree, Configuration):
+    @classmethod
+    def pre_setup(cls):
+        super().pre_setup()
+
+    @classmethod
+    def setup(cls):
+        super().setup()
+
+    @classmethod
+    def post_setup(cls):
+        super().post_setup()
+
+
+class SharedSettingsDeployment(Secure, Sentry, SharedSettings):
+    @classmethod
+    def pre_setup(cls):
+        super().pre_setup()
+
+    @classmethod
+    def setup(cls):
+        super().setup()
+
+    @classmethod
+    def post_setup(cls):
+        super().post_setup()

--- a/donate/settings/shared_settings.py
+++ b/donate/settings/shared_settings.py
@@ -22,7 +22,7 @@ class SharedSettings(Base, OIDC, Database, Redis, S3, Braintree, Configuration):
         super().post_setup()
 
 
-class SharedSettingsDeployment(Secure, Sentry, SharedSettings):
+class SharedSettingsDeployment(SharedSettings, Secure, Sentry):
     @classmethod
     def pre_setup(cls):
         super().pre_setup()

--- a/donate/settings/staging.py
+++ b/donate/settings/staging.py
@@ -1,17 +1,9 @@
-from configurations import Configuration
 from .environment import env
-from .base import Base
-from .secure import Secure
-from .oidc import OIDC
-from .database import Database
-from .redis import Redis
-from .s3 import S3
-from .braintree import Braintree
-from .sentry import Sentry
+from .shared_settings import SharedSettingsDeployment
 from .thunderbird import ThunderbirdOverrides
 
 
-class Staging(Base, Secure, OIDC, Database, Redis, S3, Braintree, Sentry, Configuration):
+class Staging(SharedSettingsDeployment):
     DEBUG = False
     SECRET_KEY = env('DJANGO_SECRET_KEY')
     BASKET_API_ROOT_URL = env('BASKET_API_ROOT_URL')
@@ -32,7 +24,7 @@ class Staging(Base, Secure, OIDC, Database, Redis, S3, Braintree, Sentry, Config
         super().post_setup()
 
 
-class ThunderbirdStaging(Staging, ThunderbirdOverrides, Configuration):
+class ThunderbirdStaging(Staging, ThunderbirdOverrides):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Staging.INSTALLED_APPS
 
     @property


### PR DESCRIPTION
This unifies the three runtime environments (dev/staging/prod) so that new setting objects (e.g. Salesforce) just need to be added in a single place.

I'm not intimately familiar with the inheritance ordering that D.C. requires though, so the argument ordering might be incorrect for some of these.