### PR TITLE
Fix locale code used in share button links

### DIFF
--- a/donate/templates/payment/thank_you_master.html
+++ b/donate/templates/payment/thank_you_master.html
@@ -21,6 +21,8 @@
                 {% block buttons %}
                     {% trans "I donated to @mozilla today because I #lovetheweb. Join me and help fight for a better and healthier internet, for all." as twitter_text context "Used as a tweet" %}
                     {% trans "I donated to Mozilla today" as email_subject context "Email subject line" %}
+                    {% get_current_language as LANGUAGE_CODE %}
+                    {% with page_link=request.scheme|add:"://"|add:request.get_host|add:"/"|add:LANGUAGE_CODE %}
 
                     <a class="button button--outline button--icon js-ga-track-click" href="https://www.facebook.com/sharer/sharer.php?u=https://foundation.mozilla.org" title="{% trans 'Share on Facebook' %}" data-ga-category="Social" data-ga-action="Clicked on Button" data-ga-label="Facebook">
                         <svg class="button__icon button__icon--facebook" width="16" height="16">
@@ -35,7 +37,7 @@
                         </svg>
                         <div class="button__label">{% trans "Twitter" %}</div>
                     </a>
-                    <a class="button button--outline button--icon js-ga-track-click" href="mailto:?&amp;subject={{ email_subject|urlencode }}&amp;body={{ request.scheme }}://{{ request.get_host }}/{% get_locale %}" data-ga-category="Social" data-ga-action="Clicked on Button" data-ga-label="Email">
+                    <a class="button button--outline button--icon js-ga-track-click" href="mailto:?&amp;subject={{ email_subject|urlencode }}&amp;body={{ page_link }}" data-ga-category="Social" data-ga-action="Clicked on Button" data-ga-label="Email">
                         <svg class="button__icon button__icon--email" width="16" height="16">
                             <use xlink:href="#email"></use>
                         </svg>
@@ -52,8 +54,9 @@
                             <span class="button__initial">{% trans "Link" context "Share button" %}</span>
                             <span class="button__copied">{% trans "Copied" %}</span>
                         </div>
-                        <input class="button__hidden" type="text" value="{{ request.scheme }}://{{ request.get_host }}/{% get_locale %}" data-copy-value>
+                        <input class="button__hidden" type="text" value="{{ page_link }}" data-copy-value>
                     </a>
+                    {% endwith %}
                 {% endblock %}
             </div>
         </div>

--- a/donate/thunderbird/templates/payment/thank_you.html
+++ b/donate/thunderbird/templates/payment/thank_you.html
@@ -12,6 +12,7 @@
     {% trans "I donated to Thunderbird today" as email_subject context "Email subject line" %}
     {% get_current_language as LANGUAGE_CODE %}
     {% with page_link="https://donate.mozilla.org/"|add:LANGUAGE_CODE|add:"/thunderbird/"%}
+
     <a class="button button--outline button--icon" href="https://www.facebook.com/sharer/sharer.php?u={{ page_link }}" title="{% trans 'Share on Facebook' %}">
         <svg class="button__icon button__icon--facebook" width="16" height="16">
             <use xlink:href="#facebook"></use>

--- a/donate/thunderbird/templates/payment/thank_you.html
+++ b/donate/thunderbird/templates/payment/thank_you.html
@@ -10,21 +10,22 @@
 {% block buttons %}
     {% trans "I donated to @mozthunderbird today to #freetheinbox. Join me to support communication privacy." as twitter_text context "Used as a tweet" %}
     {% trans "I donated to Thunderbird today" as email_subject context "Email subject line" %}
-
-    <a class="button button--outline button--icon" href="https://www.facebook.com/sharer/sharer.php?u=https://donate.mozilla.org/{% get_locale %}/thunderbird/" title="{% trans 'Share on Facebook' %}">
+    {% get_current_language as LANGUAGE_CODE %}
+    {% with page_link="https://donate.mozilla.org/"|add:LANGUAGE_CODE|add:"/thunderbird/"%}
+    <a class="button button--outline button--icon" href="https://www.facebook.com/sharer/sharer.php?u={{ page_link }}" title="{% trans 'Share on Facebook' %}">
         <svg class="button__icon button__icon--facebook" width="16" height="16">
             <use xlink:href="#facebook"></use>
         </svg>
         <div class="button__label">{% trans "Facebook" %}</div>
     </a>
     {# see https://dev.twitter.com/web/tweet-button/web-intent #}
-    <a class="button button--outline button--icon" href="https://twitter.com/intent/tweet?text={{ twitter_text|urlencode }}&amp;url=https://donate.mozilla.org/{% get_locale %}/thunderbird/&amp;via=mozthunderbird" title="{% trans 'Share on Twitter' %}">
+    <a class="button button--outline button--icon" href="https://twitter.com/intent/tweet?text={{ twitter_text|urlencode }}&amp;url={{ page_link }}&amp;via=mozthunderbird" title="{% trans 'Share on Twitter' %}">
         <svg class="button__icon button__icon--twitter" width="16" height="16">
             <use xlink:href="#twitter"></use>
         </svg>
         <div class="button__label">{% trans "Twitter" %}</div>
     </a>
-    <a class="button button--outline button--icon" href="mailto:?&amp;subject={{ email_subject|urlencode }}&amp;body=https://donate.mozilla.org/{% get_locale %}/thunderbird/">
+    <a class="button button--outline button--icon" href="mailto:?&amp;subject={{ email_subject|urlencode }}&amp;body={{ page_link }}">
         <svg class="button__icon button__icon--email" width="16" height="16">
             <use xlink:href="#email"></use>
         </svg>
@@ -41,6 +42,7 @@
             <span class="button__initial">{% trans "Link" context "Share button" %}</span>
             <span class="button__copied">{% trans "Copied" %}</span>
         </div>
-        <input class="button__hidden" type="text" value="https://donate.mozilla.org/{% get_locale %}/thunderbird/" data-copy-value>
+        <input class="button__hidden" type="text" value="{{ page_link }}" data-copy-value>
     </a>
+    {% endwith %}
 {% endblock %}

--- a/donate/thunderbird/templates/payment/thank_you.html
+++ b/donate/thunderbird/templates/payment/thank_you.html
@@ -20,13 +20,13 @@
         <div class="button__label">{% trans "Facebook" %}</div>
     </a>
     {# see https://dev.twitter.com/web/tweet-button/web-intent #}
-    <a class="button button--outline button--icon" href="https://twitter.com/intent/tweet?text={{ twitter_text|urlencode }}&amp;url={{ page_link }}&amp;via=mozthunderbird" title="{% trans 'Share on Twitter' %}">
+    <a class="button button--outline button--icon" href="https://twitter.com/intent/tweet?text={{ twitter_text|urlencode }}&url={{ page_link }}&via=mozthunderbird" title="{% trans 'Share on Twitter' %}">
         <svg class="button__icon button__icon--twitter" width="16" height="16">
             <use xlink:href="#twitter"></use>
         </svg>
         <div class="button__label">{% trans "Twitter" %}</div>
     </a>
-    <a class="button button--outline button--icon" href="mailto:?&amp;subject={{ email_subject|urlencode }}&amp;body={{ page_link }}">
+    <a class="button button--outline button--icon" href="mailto:?&subject={{ email_subject|urlencode }}&body={{ page_link }}">
         <svg class="button__icon button__icon--email" width="16" height="16">
             <use xlink:href="#email"></use>
         </svg>


### PR DESCRIPTION
Locale code should be in `ab-CD` format and not `ab_CD`.

@TheoChevalier please review this on Friday when you start (aka during regular hours 😉 )

I'm just fixing the share buttons portion of it. If you think there are more `get_locale` related fixes that we need to do, can you file a follow-up ticket? Thanks!