### PR TITLE
Fix issue 716: custom value can have a value while showing as empty

### DIFF
--- a/source/js/components/currency-selector.js
+++ b/source/js/components/currency-selector.js
@@ -202,10 +202,16 @@ class CurrencySelect {
     const presets = document.querySelectorAll(
       ".donation-amount__radio:not([data-other-amount-radio])"
     );
+
+    const customAmounts = document.querySelectorAll(
+      "[data-other-amount-radio]"
+    );
+
     presets.forEach(input => {
       input.addEventListener("change", _ => {
         if (input.checked) {
           otherAmountInputs.forEach(other => (other.value = ""));
+          customAmounts.forEach(other => (other.value = ""));
         }
       });
     });


### PR DESCRIPTION
This PR fixes issue #716 

After a bit of console logging, I've traced to the source of the problem:

In the original event listener defined for when clicking on preset donation amounts, only the values for html elements containing tag `data-other-amount` were cleared. However, the actual custom donation amount being submitted through the form is stored in the html element containing tag `data-other-amount-radio`, which was not cleared.

I modified the event listener for clicking on preset donation amounts to clear values stored in html elements with tag `data-other-amount-radio` as well.