### PR TITLE
Update Wagtail Localize

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -33,8 +33,8 @@ sentry-sdk = "==0.13.5"
 stripe = ">=2.40.0,<3"
 wagtail = "==2.6.3"
 wagtail-factories = "*"
-wagtail-localize = ">=0.3.2"
-wagtail-localize-pontoon = ">=0.1.4"
+wagtail-localize = ">=0.4,<0.5"
+wagtail-localize-pontoon = ">=0.2,<0.3"
 whitenoise = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8fa2ce989fff0450f428f5dd77a14df8985ab4de4104edb747f1d281fc40236c"
+            "sha256": "878f951a6176d57ba3031c86f70f6eb03056959be7719e8e2158e7b43c75885f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,11 +49,11 @@
         },
         "braintree": {
             "hashes": [
-                "sha256:1142d5db83b170bdee3911897323974de589bbb573d3c9a16179d4d8c638bcbc",
-                "sha256:21dbeb57a02c2da78dd249a46e8f54ba1ea6ce424430132e004dd044868ab57d"
+                "sha256:44ca396aa9a81f8d77655da92ec6473ca419b57c7228117f2643ba38474d1359",
+                "sha256:e628c482bbd3b6249d1c5d587a48fc92bce3887089a410ebd2d54ae4ae20e407"
             ],
             "index": "pypi",
-            "version": "==3.57.1"
+            "version": "==3.58.0"
         },
         "certifi": {
             "hashes": [
@@ -174,11 +174,11 @@
         },
         "django-csp": {
             "hashes": [
-                "sha256:04600237701e6d6ff78ed7d41209ff923988148bf292c128f6b474b9befe444f",
-                "sha256:8b9997df89a7a936d7c397e051367f974aa1d1a97d0b32acb4300087b3bed071"
+                "sha256:0a38aa9618c675cbf5f5e517e20d5846a3e100ef7b307e32e7fb18c58aa47723",
+                "sha256:d9ee5a8c6442aa54854e8de627c2826786208ed38fb4ea8ced08c42332673eb1"
             ],
             "index": "pypi",
-            "version": "==3.5"
+            "version": "==3.6"
         },
         "django-environ": {
             "hashes": [
@@ -270,11 +270,11 @@
         },
         "freezegun": {
             "hashes": [
-                "sha256:2a4d9c8cd3c04a201e20c313caf8b6338f1cfa4cda43f46a94cc4a9fd13ea5e7",
-                "sha256:edfdf5bc6040969e6ed2e36eafe277963bdc8b7c01daeda96c5c8594576c9390"
+                "sha256:6125965e9bd268cff7da54e4f5c02101b713e2db94a123b20c3e3c0b1f5a991e",
+                "sha256:92083290d95e796fc10bbe2d1278e812ab773395b5387083d88a6d9a604a797b"
             ],
             "index": "pypi",
-            "version": "==0.3.12"
+            "version": "==0.3.13"
         },
         "gitdb2": {
             "hashes": [
@@ -285,10 +285,10 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:947cc75913e7b6da108458136607e2ee0e40c20be1e12d4284e7c6c12956c276",
-                "sha256:d2f4945f8260f6981d724f5957bc076398ada55cb5d25aaee10108bcdc894100"
+                "sha256:9c2398ffc3dcb3c40b27324b316f08a4f93ad646d5a6328cafbb871aa79f5e42",
+                "sha256:c155c6a2653593ccb300462f6ef533583a913e17857cfef8fc617c246b6dc245"
             ],
-            "version": "==3.0.2"
+            "version": "==3.0.5"
         },
         "gunicorn": {
             "hashes": [
@@ -422,31 +422,21 @@
         },
         "pygit2": {
             "hashes": [
-                "sha256:1d3612aec07e351e801b95ad02584e7964a011aee3d3e0c77f6ce44941bd82c8",
-                "sha256:478ef2f8d5e9f8a230f8c76d2ebfdf8324764d537224d2ad947e1b3d5b5ef52f",
-                "sha256:4abf6feea2cdda63503abc552ed281d1dac622d51d44076135d76a1e7de36512",
-                "sha256:4d8c3fbbf2e5793a9984681a94e6ac2f1bc91a92cbac762dbdfbea296b917f86",
-                "sha256:646844b9178fa710da311b75fae2ffe5c51f18da375b9e93a0b3191324b1eac8",
-                "sha256:6482ee9acc572768338b7364ed0df17c3ac10c5cc3a1c60492b5d025e2fcaec2",
-                "sha256:6f44ee84fbe9b0b69f018dbe187d01a1949ab33f2cb5844d87a1929ccbd2b310",
-                "sha256:754fcbc7fa5e2766e2c10f14a8fe605eafee3e6f700cc63093cdee6f02469d15",
-                "sha256:77b6c288e020f323e3345310b5a99bc12d68d719765c2dc588fd456780d95d9e",
-                "sha256:7d8a0abfc85c79d6bcd5707046616a93d33b819e1043cfb9a08509ca40336934",
-                "sha256:90450f825b5d5e0f32b1daa4997435b1a434cd361d31a5f675db3954efb02a53",
-                "sha256:a75ca9eba1fb5f8a10bca7294ec22f0b30e0f62b25a6eccd993405ca5ceeb84b",
-                "sha256:a75e55ab3e67430474938e5286dbb2597976715c0bfcb1747e89be6d6092f8aa",
-                "sha256:be5a472cbd400099be4cc4c14d6f291d9d64edcc06a70239deae6a81c536e389",
-                "sha256:cdfe326c51c2b431dd9e4f5992a7d26e36d46091cab2b11b3d34f2fbb10bed34",
-                "sha256:ceaedf1c8ea2dab34bab0b08d233d7b4397a11674a560f07bd8155b824774028",
-                "sha256:d389e1aa81fffc55262a686d9f1dfd5ea245d441fdc37b9c7e177603aecfb712",
-                "sha256:d3a1b98208c42035fff54ed435f5ea9f0be9064f0307dbb58a3f006440fd8088",
-                "sha256:d4c84cd7c5a3d71757933d190018f5fc131aeb392d304ba9c505e9e95473f935",
-                "sha256:e2b3643e8f91b47180f9d98312eb057c55b78386d120a1a6e8c9604980efedc5",
-                "sha256:ee54ebba24ac5d628da6d3f79086a8046d8b0038f08a8e84df934db316f3eab0",
-                "sha256:eff55e52cbfc0d298197dcc3bb55fadd9d43bf31cd47211c249d04c496672911",
-                "sha256:f1d99e6f67438950d44f70e12469088239288f458fa8b660da6f9f1c7138ef22"
+                "sha256:1176efc3899ee1e0e3fba47a610b6f3e1783385de13d81044da702d5bce15b5b",
+                "sha256:11c5a7b72d8c92d8a7650ae520a8d92c976a680cf47dd61ed92feb0d65575847",
+                "sha256:11db866707ea174f98d33b9d777409dab1f21ef2332915916e93ee3f1cf4714d",
+                "sha256:25da62e7c4542e8898a6d6ab59775841963ad43a5eb5ec551e534cbb7fe3fc24",
+                "sha256:3b60c7037454d4d4ac6ddfef5f7afc4c3115143e5c18ae1cb90a8a9e514691fa",
+                "sha256:4b7ffbd09a0e5da3f24c8913498fc628a5f27e171a2e0509890403b6cbe1f333",
+                "sha256:5ac57ef32d0b7edb57e0dc49a02c52477821539827dcdac415d54c4cf66b1af2",
+                "sha256:6313c0febdf21173bb6d6088c760b0f9ec3887e8afaa14e53b8003c82cada97c",
+                "sha256:9429a998cfdc76ccea8512277c6581f75a30099fe4dfbe7a5a10c541013180a9",
+                "sha256:a8cd17ca7ccf3585b031dded74a7dcb00fc3231aa1cc00d98eecbafe20c5378d",
+                "sha256:b7c0abce8cfe4b570e78d16627fe44e76004a96f6cb1c77c8a3ffe8ce37dd2b0",
+                "sha256:c316248dae9f2a1d79275dc36f7d3200b217931367c6c37eda751d7ea6f441dc",
+                "sha256:d6c1864da421ad41f0548a58b2e2d9d808e55bccde80a8b047aa1027f687213d"
             ],
-            "version": "==0.28.2"
+            "version": "==1.0.2"
         },
         "pyopenssl": {
             "hashes": [
@@ -534,11 +524,11 @@
         },
         "stripe": {
             "hashes": [
-                "sha256:31b26a3d6d7c396fe9dee1a7b38c241d158a3e68eac5e4bf52b87af970260c93",
-                "sha256:a84d67bfd0baaf732e7aaf434092923b840d46a94871eb560ed9fac9c531e962"
+                "sha256:89b2dcf6a84f0433cc15908c7be23f06a88e472065bb4f7542470ad97c053aef",
+                "sha256:eb5c2c35b2d31eaccb43983ca83de513b335100d9b71e79ca4c60085da464b77"
             ],
             "index": "pypi",
-            "version": "==2.41.1"
+            "version": "==2.42.0"
         },
         "text-unidecode": {
             "hashes": [
@@ -586,19 +576,19 @@
         },
         "wagtail-localize": {
             "hashes": [
-                "sha256:188a71257dcf8ce14cafc50698527ee5787eb55e2f653e539d3aa85de124c99f",
-                "sha256:c82daeba7c0ffab972ae923818eff6ab6eb37050fefdafdbef8157c1aa552daa"
+                "sha256:899a3113fef8ef3090270cbc35eeeb82ad6b88b1087da01b4438abb14f3195d9",
+                "sha256:a23aeb8e1505c604d31257927c3a64403488f14bbd557bc46747f47bf52c9ae6"
             ],
             "index": "pypi",
-            "version": "==0.3.3"
+            "version": "==0.4"
         },
         "wagtail-localize-pontoon": {
             "hashes": [
-                "sha256:167c5947704ed64bdae53ee76061b35ed0ef798e1ae874505c73e90ed2faa852",
-                "sha256:523d24b1dba6a6b06f6b4e9c2b1888d6cf05de9d527dc37781cfe7242d1a1355"
+                "sha256:31e754136d51c34b298fac9219786a24fe48cebe132d142679d88e1ff0944f40",
+                "sha256:65154910bb7d9dbd136d3cd8d88ff81cabd7a334c152a1afa9656ee079787b49"
             ],
             "index": "pypi",
-            "version": "==0.1.4"
+            "version": "==0.2"
         },
         "webencodings": {
             "hashes": [

--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -77,7 +77,8 @@ class Base(object):
 
         'wagtail_localize',
         'wagtail_localize.admin.language_switch',
-        'wagtail_localize.translation_memory',
+        'wagtail_localize.deprecated.translation_memory',
+        'wagtail_localize.translation',
         'wagtail_localize_pontoon',
 
         'wagtail.contrib.settings',


### PR DESCRIPTION
This updates Wagtail localize to 0.4 and Wagtail localize pontoon to 0.2.

Release notes:
 - [Wagtail localize 0.4](https://github.com/wagtail/wagtail-localize/releases/tag/v0.4)
 - [Wagtail localize Pontoon 0.2](https://github.com/wagtail/wagtail-localize-pontoon/releases/tag/v0.2)

After updating and migrating, you must run the following commands:

```
django-admin submit_whole_site_to_pontoon
```

This regenerates submissions for all the pages in the site (previous ones will be deleted by the migration).

```
django-admin sync_pontoon
```

This will update the PO files, the folder structure has changed to include `pages/` at the top level (since snippets now exist as separate resources). Also, all messages now have a `msgctxt` field so this command adds that too.

Fixes these issues:
 - [Wagtail edits translations of the same source string across files when they differ in the target language](https://github.com/mozilla/donate-wagtail/issues/563)
 - [Italic text is not properly extracted in .po files](https://github.com/mozilla/donate-wagtail/issues/586)
 - [Localized links are non functional](https://github.com/mozilla/donate-wagtail/issues/561)
 - [wagtail-localize-pontoon stopped syncing](https://github.com/mozilla/donate-wagtail/issues/588)