### PR TITLE
Fix Sentry for django

### DIFF
--- a/donate/settings/sentry.py
+++ b/donate/settings/sentry.py
@@ -7,8 +7,8 @@ class Sentry(object):
     HEROKU_RELEASE_VERSION = env('HEROKU_RELEASE_VERSION')
 
     @classmethod
-    def setup(cls):
-        super().setup()
+    def pre_setup(cls):
+        super().pre_setup()
 
         import sentry_sdk
         from sentry_sdk.integrations.django import DjangoIntegration


### PR DESCRIPTION
Sentry must be configured as `pre_setup` not `setup`.