### PR TITLE
Separate GA ids for thunderbird and foundation

### DIFF
--- a/donate/templates/base_master.html
+++ b/donate/templates/base_master.html
@@ -8,6 +8,9 @@
         <title>{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %} | {% trans 'Donate to Mozilla' context 'Page title' %}{% endblock %}</title>
         <meta name="description" content="{% if page.search_description %}{{ page.search_description }}{% endif %}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        {% block ga_identifier %}
+        <meta name="ga-identifier" content="UA-49796218-32">
+        {% endblock %}
         {% block meta_tags %}{% endblock %}
 
         <link rel="apple-touch-icon" sizes="180x180" href="{% static '_images/favicon/apple-touch-icon.png' %}">

--- a/donate/thunderbird/templates/base.html
+++ b/donate/thunderbird/templates/base.html
@@ -2,4 +2,8 @@
 
 {% load i18n %}
 
+{% block ga_identifier %}
+<meta name="ga-identifier" content="UA-87658599-20">
+{% endblock %}
+
 {% block title_suffix %} | {% trans 'Give to Thunderbird' context 'Page title' %}{% endblock %}

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -34,6 +34,12 @@ function closeMenu() {
 }
 
 document.addEventListener("DOMContentLoaded", function() {
+  const gaMeta = document.querySelector(`meta[name="ga-identifier"]`);
+  if (gaMeta) {
+    let gaIdentifier = gaMeta.getAttribute(`content`);
+    initializeGA(gaIdentifier);
+  }
+
   // Initialize Sentry error reporting
 
   fetchEnv(envData => {
@@ -88,7 +94,7 @@ document.addEventListener("DOMContentLoaded", function() {
 });
 
 // Google Analytics
-(function() {
+function initializeGA(trackingId) {
   var doNotTrack =
     navigator.doNotTrack || navigator.msDoNotTrack || window.doNotTrack;
   if (!doNotTrack || doNotTrack === "no" || doNotTrack === "unspecified") {
@@ -113,7 +119,7 @@ document.addEventListener("DOMContentLoaded", function() {
     );
 
     if (typeof ga === "function") {
-      ga("create", "UA-49796218-32", "auto");
+      ga("create", trackingId, "auto");
 
       // Ensure we don't pass the email query param to Google Analytics
       var loc = window.location,
@@ -158,4 +164,4 @@ document.addEventListener("DOMContentLoaded", function() {
       });
     }
   }
-})();
+}


### PR DESCRIPTION
This is so that we can setup different GA tracking IDs for MZLA and the foundation.