### PR TITLE
Make salesforce help forms work

### DIFF
--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -303,5 +303,7 @@ class ContributorSupportPage(TranslatablePageMixin, Page):
         ctx = super().get_context(request)
         ctx.update({
             'orgid': settings.SALESFORCE_ORGID,
+            'record_type_id': settings.SALESFORCE_CASE_RECORD_TYPE_ID,
+            'salesforce_form_url': settings.SALESFORCE_FORM_URL,
         })
         return ctx

--- a/donate/settings/environment.py
+++ b/donate/settings/environment.py
@@ -58,6 +58,7 @@ env = environ.Env(
     REDIS_URL=(str, 'redis://redis:6397/0'),
     REVIEW_APP=(bool, False),
     SALESFORCE_ORGID=(str, ''),
+    SALESFORCE_FORM_URL=(str, ''),
     SENTRY_DSN=(str, None),
     SENTRY_ENVIRONMENT=(str, None),
     SET_HSTS=(bool, False),

--- a/donate/settings/environment.py
+++ b/donate/settings/environment.py
@@ -59,6 +59,7 @@ env = environ.Env(
     REVIEW_APP=(bool, False),
     SALESFORCE_ORGID=(str, ''),
     SALESFORCE_FORM_URL=(str, ''),
+    SALESFORCE_CASE_RECORD_TYPE_ID=(str, ''),
     SENTRY_DSN=(str, None),
     SENTRY_ENVIRONMENT=(str, None),
     SET_HSTS=(bool, False),

--- a/donate/settings/production.py
+++ b/donate/settings/production.py
@@ -13,6 +13,7 @@ from .thunderbird import ThunderbirdOverrides
 
 class Production(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree, Sentry, Configuration):
     DEBUG = False
+    SALESFORCE_FORM_URL = "https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8"
 
     @classmethod
     def pre_setup(cls):
@@ -33,6 +34,7 @@ class Production(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree,
 class ThunderbirdProduction(Production, ThunderbirdOverrides, Configuration):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Production.INSTALLED_APPS
     ENABLE_THUNDERBIRD_REDIRECT = False
+    SALESFORCE_CASE_RECORD_TYPE_ID = "0124O000000tDBO"
 
     @property
     def TEMPLATES(self):

--- a/donate/settings/salesforce.py
+++ b/donate/settings/salesforce.py
@@ -3,3 +3,5 @@ from .environment import env
 
 class Salesforce(object):
     SALESFORCE_ORGID = env('SALESFORCE_ORGID')
+    SALESFORCE_FORM_URL = env('SALESFORCE_FORM_URL')
+    SALESFORCE_CASE_RECORD_TYPE_ID = env('SALESFORCE_CASE_RECORD_TYPE_ID')

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -24,7 +24,7 @@
                     <p class="rich-text">{% trans "We will get back to you soon." %}</p>
                 </div>
             {% else %}
-                <form class="" action="https://mozillasalescloud--mkl.cs4.my.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8" method="POST">
+                <form class="" action="{{ salesforce_form_url }}" method="POST">
                     <p class="rich-text">{% blocktrans trimmed %}
                         If you need help with a contribution, fill out this form and we’ll get back to you soon.
                     {% endblocktrans %}</p>

--- a/donate/thunderbird/templates/pages/core/contributor_support_page.html
+++ b/donate/thunderbird/templates/pages/core/contributor_support_page.html
@@ -1,6 +1,6 @@
 {% extends "pages/core/contributor_support_page_master.html" %}
 
 {% block custom_hidden_fields %}
-    <input type=hidden name="recordType" id="recordType" value="012P0000000SW6LIAW">
+    <input type=hidden name="recordType" id="recordType" value="{{record_type_id}}">
     <input type=hidden name="type" value="Thunderbird">
 {% endblock %}


### PR DESCRIPTION
This isn't pretty, but it works. I'm open to alternative approaches...once we launch this, but I was moving in the direction of the code we already had.

Steph has confirmed that this makes cases appear in the right place.

```
SALESFORCE_ORGID=00DU0000000IrgO
SALESFORCE_CASE_RECORD_TYPE_ID=0124O000000tDBO
CSP_FORM_ACTION=https://webto.salesforce.com/
SALESFORCE_FORM_URL=https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8
```

(Some of these are baked into the production djangoconfig)