### PR TITLE
Fix TB Monthlies

### DIFF
--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -161,7 +161,8 @@ class Base(object):
     FRONTEND = {
         'RELEASE_VERSION': env('HEROKU_RELEASE_VERSION'),
         'SENTRY_DSN': env('SENTRY_DSN'),
-        'SENTRY_ENVIRONMENT': env('SENTRY_ENVIRONMENT')
+        'SENTRY_ENVIRONMENT': env('SENTRY_ENVIRONMENT'),
+        'BRAINTREE_MERCHANT_ACCOUNTS': env('BRAINTREE_MERCHANT_ACCOUNTS')
     }
 
     @classmethod

--- a/source/js/components/env.js
+++ b/source/js/components/env.js
@@ -1,0 +1,18 @@
+export default function fetchEnv(callback) {
+  let envReq = new XMLHttpRequest();
+
+  envReq.addEventListener("load", () => {
+    let envData;
+
+    try {
+      envData = JSON.parse(envReq.response);
+    } catch (e) {
+      // discard
+    }
+
+    callback(envData);
+  });
+
+  envReq.open("GET", "/environment.json");
+  envReq.send();
+}

--- a/source/js/components/env.js
+++ b/source/js/components/env.js
@@ -1,4 +1,4 @@
-export default function fetchEnv(callback) {
+export default function fetchEnv(handleEnvData) {
   let envReq = new XMLHttpRequest();
 
   envReq.addEventListener("load", () => {

--- a/source/js/components/env.js
+++ b/source/js/components/env.js
@@ -2,7 +2,7 @@ export default function fetchEnv(handleEnvData) {
   let envReq = new XMLHttpRequest();
 
   envReq.addEventListener("load", () => {
-    let envData;
+    let envData = {};
 
     try {
       envData = JSON.parse(envReq.response);

--- a/source/js/components/env.js
+++ b/source/js/components/env.js
@@ -10,7 +10,7 @@ export default function fetchEnv(handleEnvData) {
       // discard
     }
 
-    callback(envData);
+    handleEnvData(envData);
   });
 
   envReq.open("GET", "/environment.json");

--- a/source/js/components/paypal.js
+++ b/source/js/components/paypal.js
@@ -1,6 +1,7 @@
 import client from "braintree-web/client";
 import { create as paypalCreate } from "braintree-web/paypal-checkout";
 import gaEvent from "./analytics";
+import fetchEnv from "./env";
 
 export default function initPaypal(
   getAmount,
@@ -30,81 +31,87 @@ export default function initPaypal(
     errorDiv.innerHTML = "";
   };
 
-  client.create({ authorization: braintreeParams.token }, function(
-    clientErr,
-    clientInstance
-  ) {
-    if (clientErr) {
-      showErrorMessage(loadingErrorMsg);
-      return;
-    }
-
-    paypalCreate({ client: clientInstance }, function(
-      paypalCheckoutErr,
-      paypalCheckoutInstance
+  fetchEnv(envData => {
+    let currency = getCurrency().toLowerCase();
+    client.create({ authorization: braintreeParams.token }, function(
+      clientErr,
+      clientInstance
     ) {
-      if (paypalCheckoutErr) {
+      if (clientErr) {
         showErrorMessage(loadingErrorMsg);
         return;
       }
 
-      // Set up PayPal with the checkout.js library
-      window.paypal.Button.render(
-        {
-          env: braintreeParams.use_sandbox ? "sandbox" : "production",
-          commit: true,
-          style: {
-            size: "responsive",
-            color: "blue",
-            shape: "rect",
-            label: "paypal",
-            tagline: "false"
+      paypalCreate({
+        client: clientInstance,
+        merchantAccountId: envData.BRAINTREE_MERCHANT_ACCOUNTS[currency]
+      }, function(
+        paypalCheckoutErr,
+        paypalCheckoutInstance
+      ) {
+        if (paypalCheckoutErr) {
+          showErrorMessage(loadingErrorMsg);
+          return;
+        }
+
+        // Set up PayPal with the checkout.js library
+        window.paypal.Button.render(
+          {
+            env: braintreeParams.use_sandbox ? "sandbox" : "production",
+            commit: true,
+            style: {
+              size: "responsive",
+              color: "blue",
+              shape: "rect",
+              label: "paypal",
+              tagline: "false"
+            },
+
+            payment: function() {
+              return paypalCheckoutInstance.createPayment({
+                flow: flow,
+                amount: getAmount(),
+                currency: getCurrency(),
+                enableShippingAddress: false
+              });
+            },
+
+            onAuthorize: function(data) {
+              return paypalCheckoutInstance.tokenizePayment(data, function(
+                err,
+                payload
+              ) {
+                if (err) {
+                  showErrorMessage(generalErrorMsg);
+                  return;
+                }
+
+                onAuthorize(payload);
+              });
+            },
+
+            onCancel: function() {
+              showErrorMessage(window.gettext("Payment cancelled"));
+              gaEvent({
+                eventCategory: "User Flow",
+                eventAction: "Paypal Payment Cancelled"
+              });
+            },
+
+            onError: function(err) {
+              showErrorMessage(generalErrorMsg);
+              gaEvent({
+                eventCategory: "User Flow",
+                eventAction: "PayPal Error"
+              });
+            }
           },
-
-          payment: function() {
-            return paypalCheckoutInstance.createPayment({
-              flow: flow,
-              amount: getAmount(),
-              currency: getCurrency(),
-              enableShippingAddress: false
-            });
-          },
-
-          onAuthorize: function(data) {
-            return paypalCheckoutInstance.tokenizePayment(data, function(
-              err,
-              payload
-            ) {
-              if (err) {
-                showErrorMessage(generalErrorMsg);
-                return;
-              }
-
-              onAuthorize(payload);
-            });
-          },
-
-          onCancel: function() {
-            showErrorMessage(window.gettext("Payment cancelled"));
-            gaEvent({
-              eventCategory: "User Flow",
-              eventAction: "Paypal Payment Cancelled"
-            });
-          },
-
-          onError: function(err) {
-            showErrorMessage(generalErrorMsg);
-            gaEvent({
-              eventCategory: "User Flow",
-              eventAction: "PayPal Error"
-            });
-          }
-        },
-        buttonId
-      ).then(function() {
-        // The PayPal button will be rendered in an html element with the id
-        // specified in buttonId. This function will be called when the PayPal button
-        // is set up and ready to be used.
+          buttonId
+        ).then(function() {
+          // The PayPal button will be rendered in an html element with the id
+          // specified in buttonId. This function will be called when the PayPal button
+          // is set up and ready to be used.
+        });
       });
     });
   });

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -46,8 +46,6 @@ document.addEventListener("DOMContentLoaded", function() {
       release: envData.RELEASE_VERSION,
       environment: envData.SENTRY_ENVIRONMENT
     });
-
-    window.BRAINTREE_MERCHANT_ACCOUNTS = envData.BRAINTREE_MERCHANT_ACCOUNTS;
   });
 
   for (const menutoggle of document.querySelectorAll(MenuToggle.selector())) {

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -10,23 +10,7 @@ import DonationCurrencyWidth from "./components/donation-currency-width";
 import CopyURL from "./components/copy-url";
 import Accordion from "./components/accordion";
 import "./components/newsletter";
-
-function fetchEnv(callback) {
-  let envReq = new XMLHttpRequest();
-
-  envReq.addEventListener("load", () => {
-    let data = {};
-    try {
-      data = JSON.parse(envReq.response);
-    } catch (e) {
-      // discard
-    }
-    callback(data);
-  });
-
-  envReq.open("GET", "/environment.json");
-  envReq.send();
-}
+import fetchEnv from "./components/env"
 
 // Manage tab index for primary nav
 function tabIndexer() {
@@ -62,6 +46,8 @@ document.addEventListener("DOMContentLoaded", function() {
       release: envData.RELEASE_VERSION,
       environment: envData.SENTRY_ENVIRONMENT
     });
+
+    window.BRAINTREE_MERCHANT_ACCOUNTS = envData.BRAINTREE_MERCHANT_ACCOUNTS;
   });
 
   for (const menutoggle of document.querySelectorAll(MenuToggle.selector())) {

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -10,7 +10,7 @@ import DonationCurrencyWidth from "./components/donation-currency-width";
 import CopyURL from "./components/copy-url";
 import Accordion from "./components/accordion";
 import "./components/newsletter";
-import fetchEnv from "./components/env"
+import fetchEnv from "./components/env";
 
 // Manage tab index for primary nav
 function tabIndexer() {

--- a/source/js/payments-paypal.js
+++ b/source/js/payments-paypal.js
@@ -100,7 +100,7 @@ function setupPaypalOverlays() {
     // also get the currency label, because it's "clickable".
     let otherLabel = form.querySelector(".donation-amount-other__label");
     let otherInput = document.getElementById(otherLabel.getAttribute("for"));
-    console.log(otherLabel, otherInput);
+
     otherLabel.addEventListener("click", _ => toggle(overlay, otherInput));
 
     overlay.addEventListener("click", () => {


### PR DESCRIPTION
This PR passes the merchant account ID to paypalCreate, so that billing agreements aren't automatically associated with the default Merchant Account in Braintree.

I noticed that it's set to the merchant account associated with the selected currency at page load, and doesn't switch when you change currency. Not sure if that's a problem or something we need to fix.