### PR TITLE
Fix monthly donation redirect issue

### DIFF
--- a/donate/payments/tests/test_views.py
+++ b/donate/payments/tests/test_views.py
@@ -56,6 +56,7 @@ class MockBraintreePaymentMethod:
         'first_name': 'Bob',
         'last_name': 'Jones'
     }
+    card_type = 'Visa'
 
 
 class MockBraintreeCustomer:

--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -326,9 +326,9 @@ class CardPaymentView(BraintreePaymentMixin, FormView):
             self.set_session_data(
                 result,
                 form,
-                payment_method = payment_method,
-                transaction_id = result.subscription.id,
-                last_4 = payment_method.last_4,
+                payment_method=payment_method,
+                transaction_id=result.subscription.id,
+                last_4=payment_method.last_4,
             )
             return HttpResponseRedirect(self.get_success_url())
         else:


### PR DESCRIPTION
fixes #808 

This bug is happening because in https://github.com/mozilla/donate-wagtail/pull/621 we refactored the `success` path for transactions. In doing so, we neglected to notice that the success method was setting session data that was used by the `card/thank-you/` view to tell if someone had actually made a transaction. This resulted in the subscription getting _created_ in Braintree, but the thank-you page issuing a 302 redirect to `/`. We did not catch this because if a browser has made a previous successful donation (as is the case when testing!) it _does not_ redirect.

To fix this, I've separated out the code that sets session data into a new method and ensured it's called in the monthly subscription view handler. There was additional work required to get the right data where I needed, and some test mock updates.

There may be follow-up work here to clean up session data on loading a donation landing page or card payment view to prevent the hiding of this error.

Testing
=====
### failure case
- Visit [staging](https://donate-wagtail.mofostaging.net/)
- Clear cookies for this domain (browser dependent)
- Select monthly donation, any amount
- select the card button
- Fill out the form
- submit form
- you should end up back on the site's landing page

### Success Case
- Visit review app
- Clear cookies for this domain (browser dependent)
- Select monthly donation, any amount
- select the card button
- Fill out the form
- submit form
- It should load the stay-in-touch page