### PR TITLE
Resize but not crop the image shown on landing page

### DIFF
--- a/donate/templates/pages/core/landing_page_master.html
+++ b/donate/templates/pages/core/landing_page_master.html
@@ -9,9 +9,9 @@
             <div class="image-feature column-spacing">
                 {% block featured_image %}
                     <div class="image-feature__container">
-                        {% image page.featured_image fill-290x95 as imageMobile %}
-                        {% image page.featured_image fill-690x183 as imageTablet %}
-                        {% image page.featured_image fill-350x197 as imageDesktop %}
+                        {% image page.featured_image width-290 as imageMobile %}
+                        {% image page.featured_image width-690 as imageTablet %}
+                        {% image page.featured_image width-350 as imageDesktop %}
                         <img srcset="{{ imageMobile.url }} 290w,
                                     {{ imageTablet.url }} 690w,
                                     {{ imageDesktop.url }} 350w"

--- a/donate/thunderbird/templates/pages/core/landing_page.html
+++ b/donate/thunderbird/templates/pages/core/landing_page.html
@@ -8,23 +8,5 @@
 {% endif %}
 {% endblock %}
 
-{% comment %} This should probably be fixed in the main template but it's getting a lot of comments and this seems like a reasonable quick fix. https://github.com/mozilla/donate-wagtail/issues/777 {% endcomment %}
-{% block featured_image %}
-    <div class="image-feature__container">
-        {% image page.featured_image fill-290x95 as imageMobile %}
-        {% image page.featured_image fill-690x183 as imageTablet %}
-        {% image page.featured_image fill-690x183 as imageDesktop %}
-        <img srcset="{{ imageMobile.url }} 290w,
-                        {{ imageTablet.url }} 690w,
-                        {{ imageDesktop.url }} 350w"
-                sizes="(max-width: 399px) 290px,
-                    (max-width: 1023px) and (min-width: 400px) 690px,
-                    (min-width: 1024px) 350px"
-                src="{{ imageDesktop.url }}"
-                alt="{{ image.alt }}"
-                class="image-feature__image">
-    </div>
-{% endblock %}
-
 {% block logo_showcase %}
 {% endblock %}


### PR DESCRIPTION
Closes #777

To test, resize your browser window & zoom in/out to make sure image shows up well.

Note: The is [the original image](https://assets.mofoprod.net/network/images/highlights/fellowships-that-empower-leaders_1522788145.jpg) I uploaded to the donate review app.