### PR TITLE
handle non-number values in the amount query parameter

### DIFF
--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -109,7 +109,10 @@ class DonationPage(TranslatablePageMixin, Page):
 
     def get_initial_amount(self, request):
         amount = request.GET.get('amount', 0)
-        return Decimal(amount).quantize(Decimal('0.01'))
+        try:
+            return Decimal(amount).quantize(Decimal('0.01'))
+        except InvalidOperation:
+            return 0
 
     def get_context(self, request):
         ctx = super().get_context(request)

--- a/donate/core/tests/test_models.py
+++ b/donate/core/tests/test_models.py
@@ -202,6 +202,14 @@ class CampaignPageTestCase(TestCase):
             DonationPage().currencies['usd']['presets']['single']
         )
 
+    def test_get_initial_amount_as_expected(self):
+        request = RequestFactory().get('/?amount=12.34')
+        self.assertEqual(DonationPage().get_initial_amount(request), Decimal(12.34).quantize(Decimal('0.01')))
+
+    def test_get_initial_amount_defaults_to_0(self):
+        request = RequestFactory().get('/?amount=not_a_number')
+        self.assertEqual(DonationPage().get_initial_amount(request), 0)
+
 
 class MissingMigrationsTests(TestCase):
 


### PR DESCRIPTION
Fixes the unhandled exception that paged me and woke up the baby 😒 

Incident: https://portal.victorops.com/ui/mozilla-foundation/incident/210/details/
Sentry: https://sentry.prod.mozaws.net/share/issue/67ea8903375c4686ab728f03472234f3/