### PR TITLE
Add a "covid notice" to the ways-to-give pages

### DIFF
--- a/donate/templates/pages/core/ways_to_give_page_master.html
+++ b/donate/templates/pages/core/ways_to_give_page_master.html
@@ -66,7 +66,7 @@
         {% block covid_notice %}
         <b>{% trans "UPDATE March 20, 2020:"%}</b>
         {% blocktrans trimmed %}
-        Please note that due to the "shelter in place" order recently implemented for California,
+        Please note that due to the “shelter in place” order recently implemented for California,
         processing and acknowledgment of check donations to the Mozilla Foundation will be indefinitely delayed.
         Rather than sending us a check, please consider making an <a href="/">online donation</a> instead.
         {% endblocktrans %}

--- a/donate/templates/pages/core/ways_to_give_page_master.html
+++ b/donate/templates/pages/core/ways_to_give_page_master.html
@@ -63,6 +63,17 @@
         {% trans "Check (via postal service)" %}
     </h2>
     <p>
+        {% block covid_notice %}
+        <b>{% trans "UPDATE March 20, 2020:"%}</b>
+        {% blocktrans trimmed %}
+        Please note that due to the "shelter in place" order recently implemented for California,
+        processing and acknowledgment of check donations to the Mozilla Foundation will be indefinitely delayed.
+        Rather than sending us a check, please consider making an <a href="/">online donation</a> instead.
+        {% endblocktrans %}
+        {% endblock %}
+    </p>
+    <!--
+    <p>
         {% block check_payee %}
             {% blocktrans with payee='Mozilla Foundation' trimmed %}
             Please send a check <strong>including your email address on the memo line</strong>, and payable (payee) to “{{payee}}”.
@@ -80,6 +91,7 @@
             USA
         {% endblock %}
     </address>
+    -->
     {% block currencies %}
         <h2>{% trans "Currencies" %}</h2>
         <p>{% trans "Select your currency to make a secure online donation:" %}</p>

--- a/donate/thunderbird/templates/pages/core/ways_to_give_page.html
+++ b/donate/thunderbird/templates/pages/core/ways_to_give_page.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-    
+
 {% block SEPA %}
     <h2 id="wire">{% trans "Bank Transfer / SEPA" %}</h2>
     <p>{% trans "We accept contributions in Euros through Single European Payment Area (SEPA) transfer, and British Pounds through BACS transfer." %}</p>
@@ -12,7 +12,7 @@
         {% endblocktrans %}
     </p>
 {% endblock %}
-    
+
 {% block euros %}
     <h3>{% trans "Euros:" %}</h3>
     <p>
@@ -41,6 +41,15 @@
         <b>{% trans "IBAN:" %}</b> GB42NWBK60000410020551
         {% block tb_memo_gbp %}<br><b>{% trans "Memo field:" %}</b> Thunderbird{% endblock %}
     </p>
+{% endblock %}
+
+{% block covid_notice %}
+    <b>{% trans "UPDATE March 20, 2020:"%}</b>
+    {% blocktrans trimmed %}
+    Please note that due to the "shelter in place" order recently implemented for California,
+    processing and acknowledgment of check donations to Thunderbird/MZLA Technologies will be indefinitely delayed.
+    Rather than sending us a check, please consider making an <a href="/">online donation</a> instead.
+    {% endblocktrans %}
 {% endblock %}
 
 {% block check_payee %}

--- a/donate/thunderbird/templates/pages/core/ways_to_give_page.html
+++ b/donate/thunderbird/templates/pages/core/ways_to_give_page.html
@@ -46,7 +46,7 @@
 {% block covid_notice %}
     <b>{% trans "UPDATE March 20, 2020:"%}</b>
     {% blocktrans trimmed %}
-    Please note that due to the "shelter in place" order recently implemented for California,
+    Please note that due to the “shelter in place” order recently implemented for California,
     processing and acknowledgment of check donations to Thunderbird/MZLA Technologies will be indefinitely delayed.
     Rather than sending us a check, please consider making an <a href="/">online donation</a> instead.
     {% endblocktrans %}


### PR DESCRIPTION
Addresses part of https://github.com/mozilla/donate-wagtail/issues/889

live (review) URLS:
- https://donate-wagta-covid-noti-3j3as2.herokuapp.com/en-US/ways-to-give/#check
- https://thunderbird-covid-notic-46afup.herokuapp.com/en-US/ways-to-give/#check