### PR TITLE
Provide PayPal with a custom DisplayName

### DIFF
--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -164,7 +164,8 @@ class Base(object):
         'RELEASE_VERSION': env('HEROKU_RELEASE_VERSION'),
         'SENTRY_DSN': env('SENTRY_DSN'),
         'SENTRY_ENVIRONMENT': env('SENTRY_ENVIRONMENT'),
-        'BRAINTREE_MERCHANT_ACCOUNTS': env('BRAINTREE_MERCHANT_ACCOUNTS')
+        'BRAINTREE_MERCHANT_ACCOUNTS': env('BRAINTREE_MERCHANT_ACCOUNTS'),
+        'PAYPAL_DISPLAY_NAME': 'Mozilla Foundation'
     }
 
     @classmethod

--- a/donate/settings/development.py
+++ b/donate/settings/development.py
@@ -40,6 +40,7 @@ class Development(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree
 
 class ThunderbirdDevelopment(Development, ThunderbirdOverrides, Configuration):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Development.INSTALLED_APPS
+    FRONTEND = ThunderbirdOverrides.FRONTEND
     ENABLE_THUNDERBIRD_REDIRECT = False
 
     @property

--- a/donate/settings/production.py
+++ b/donate/settings/production.py
@@ -32,6 +32,7 @@ class Production(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree,
 
 class ThunderbirdProduction(Production, ThunderbirdOverrides, Configuration):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Production.INSTALLED_APPS
+    FRONTEND = ThunderbirdOverrides.FRONTEND
     ENABLE_THUNDERBIRD_REDIRECT = False
     SALESFORCE_CASE_RECORD_TYPE_ID = "0124O000000tDBO"
 

--- a/donate/settings/review_app.py
+++ b/donate/settings/review_app.py
@@ -27,6 +27,7 @@ class ReviewApp(Staging, Configuration):
 
 class ThunderbirdReviewApp(ReviewApp, ThunderbirdOverrides, Configuration):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + ReviewApp.INSTALLED_APPS
+    FRONTEND = ThunderbirdOverrides.FRONTEND
 
     @property
     def TEMPLATES(self):

--- a/donate/settings/staging.py
+++ b/donate/settings/staging.py
@@ -31,6 +31,7 @@ class Staging(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree, Se
 
 class ThunderbirdStaging(Staging, ThunderbirdOverrides, Configuration):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Staging.INSTALLED_APPS
+    FRONTEND = ThunderbirdOverrides.FRONTEND
     ENABLE_THUNDERBIRD_REDIRECT = False
 
     @property

--- a/donate/settings/thunderbird.py
+++ b/donate/settings/thunderbird.py
@@ -1,6 +1,13 @@
-from .environment import app
+from .environment import app, env
 
 
 class ThunderbirdOverrides(object):
     INSTALLED_APPS = ['donate.thunderbird']
     TEMPLATES_DIR = [app('thunderbird/templates')]
+    FRONTEND = {
+        'RELEASE_VERSION': env('HEROKU_RELEASE_VERSION'),
+        'SENTRY_DSN': env('SENTRY_DSN'),
+        'SENTRY_ENVIRONMENT': env('SENTRY_ENVIRONMENT'),
+        'BRAINTREE_MERCHANT_ACCOUNTS': env('BRAINTREE_MERCHANT_ACCOUNTS'),
+        'PAYPAL_DISPLAY_NAME': 'MZLA Technologies'
+    }

--- a/source/js/components/paypal.js
+++ b/source/js/components/paypal.js
@@ -71,7 +71,8 @@ export default function initPaypal(
                   flow: flow,
                   amount: getAmount(),
                   currency: getCurrency(),
-                  enableShippingAddress: false
+                  enableShippingAddress: false,
+                  displayName: envData.PAYPAL_DISPLAY_NAME
                 });
               },
 


### PR DESCRIPTION
Fixes #884 

To test, you'll need to configure Braintree with a mocked Paypal flow. On the paypal popup, in the "Development" configuration, you'll get a link button on the bottom that says "Return to Mozilla Foundation" and in the "ThunderbirdDevelopment" configuration, you get "Return to MZLA Technologies"