### PR TITLE
Add missing classes to monthly payment icon elements

### DIFF
--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -123,16 +123,16 @@
                         <button class="donate-form__actions-button button button--primary button--rounded button--multiple-icons button--no-label payments__button payments__button--creditdebit" type="submit" formaction="{% url 'payments:card' frequency='monthly' %}">
                             <div class="button__label">{% trans "Donate" %}</div>
                             <div class="button__icons">
-                                <svg class="button__icon-item" width="27" height="13">
+                                <svg class="button__icon-item button__icon-item--discover" width="27" height="13">
                                     <use xlink:href="#card-discover"></use>
                                 </svg>
-                                <svg class="button__icon-item" width="20" height="18">
+                                <svg class="button__icon-item button__icon-item--amex" width="20" height="18">
                                     <use xlink:href="#card-amex"></use>
                                 </svg>
-                                <svg class="button__icon-item" width="32" height="18">
+                                <svg class="button__icon-item button__icon-item--mastercard" width="32" height="18">
                                     <use xlink:href="#card-mastercard"></use>
                                 </svg>
-                                <svg class="button__icon-item" width="35" height="12">
+                                <svg class="button__icon-item button__icon-item--visa" width="35" height="12">
                                     <use xlink:href="#card-visa"></use>
                                 </svg>
                             </div>


### PR DESCRIPTION
Fixes #936 

We missed adding some necessary classes to the monthly payment buttons. The classes I added will hide payment types if they're disabled in constants.py.

To test, load up the review app and select Canadian dollars, then toggle between monthly and single donations. You should not see the Amex logo in the card payments button, like you do on staging/prod right now.

This fix applies to montly forms for all currencies that don't accept certain card types.