### PR TITLE
Update disclaimer text for the Mozilla donation form

### DIFF
--- a/donate/templates/fragments/donate_form_disclaimer_master.html
+++ b/donate/templates/fragments/donate_form_disclaimer_master.html
@@ -4,7 +4,7 @@
     <p>
         {% block donation_information %}
         {% blocktrans with braintree_url='https://www.braintreepayments.com/legal/braintree-privacy-policy' paypal_url='https://www.paypal.com/us/webapps/mpp/ua/privacy-full' trimmed %}
-            Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Mozilla.
+            Mozilla is committed to your privacy; please read our <a href="https://www.mozilla.org/privacy/websites/">privacy policy here</a>. Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Mozilla.
         {% endblocktrans %}
         {% if monthly %}{% blocktrans with email='donate@mozilla.org' trimmed %}
             Monthly donations are charged each month on the same day that you donate today, and will continue until you cancel. To cancel, email us at <a href="mailto:{{ email }}">{{ email }}</a>.

--- a/donate/templates/fragments/donate_form_disclaimer_master.html
+++ b/donate/templates/fragments/donate_form_disclaimer_master.html
@@ -3,8 +3,8 @@
 <footer class="donate-form__footer">
     <p>
         {% block donation_information %}
-        {% blocktrans with braintree_url='https://www.braintreepayments.com/legal/braintree-privacy-policy' paypal_url='https://www.paypal.com/us/webapps/mpp/ua/privacy-full' trimmed %}
-            Mozilla is committed to your privacy; please read our <a href="https://www.mozilla.org/privacy/websites/">privacy policy here</a>. Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Mozilla.
+        {% blocktrans with braintree_url='https://www.braintreepayments.com/legal/braintree-privacy-policy' paypal_url='https://www.paypal.com/us/webapps/mpp/ua/privacy-full' privacy_url="https://www.mozilla.org/privacy/websites/" trimmed %}
+            Mozilla is committed to your privacy; please read our <a href="{{ privacy_url }}">privacy policy here</a>. Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Mozilla.
         {% endblocktrans %}
         {% if monthly %}{% blocktrans with email='donate@mozilla.org' trimmed %}
             Monthly donations are charged each month on the same day that you donate today, and will continue until you cancel. To cancel, email us at <a href="mailto:{{ email }}">{{ email }}</a>.

--- a/donate/thunderbird/templates/fragments/donate_form_disclaimer.html
+++ b/donate/thunderbird/templates/fragments/donate_form_disclaimer.html
@@ -10,7 +10,7 @@
 
 {% block donation_information %}
     {% blocktrans with braintree_url='https://www.braintreepayments.com/legal/braintree-privacy-policy' paypal_url='https://www.paypal.com/us/webapps/mpp/ua/privacy-full' trimmed %}
-        Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Mozilla.
+        Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Thunderbird. Please read our <a href="https://www.mozilla.org/privacy/websites/">privacy policy here</a>.
     {% endblocktrans %}
     {% if monthly %}{% blocktrans with help_url='/help' trimmed %}
         Monthly donations are charged each month on the same day that you donate today, and will continue until you cancel. To cancel, fill out <a href="{{help_url}}">this form</a>.

--- a/donate/thunderbird/templates/fragments/donate_form_disclaimer.html
+++ b/donate/thunderbird/templates/fragments/donate_form_disclaimer.html
@@ -9,8 +9,8 @@
 {% endblock %}
 
 {% block donation_information %}
-    {% blocktrans with braintree_url='https://www.braintreepayments.com/legal/braintree-privacy-policy' paypal_url='https://www.paypal.com/us/webapps/mpp/ua/privacy-full' trimmed %}
-        Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Thunderbird. Please read our <a href="https://www.mozilla.org/privacy/websites/">privacy policy here</a>.
+    {% blocktrans with braintree_url='https://www.braintreepayments.com/legal/braintree-privacy-policy' paypal_url='https://www.paypal.com/us/webapps/mpp/ua/privacy-full' privacy_url="https://www.mozilla.org/privacy/websites/" trimmed %}
+        Your payment details will be processed by <a href="{{ braintree_url }}">Braintree</a>, a PayPal company (for credit/debit cards) or <a href="{{ paypal_url }}">PayPal</a>, and a record of your donation will be stored by Thunderbird. Please read our <a href="{{ privacy_url }}">privacy policy here</a>.
     {% endblocktrans %}
     {% if monthly %}{% blocktrans with help_url='/help' trimmed %}
         Monthly donations are charged each month on the same day that you donate today, and will continue until you cancel. To cancel, fill out <a href="{{help_url}}">this form</a>.


### PR DESCRIPTION
Closes #1053 

Add the text and link relating to Mozilla's websites privacy policy.