### PR TITLE
update to python 3.7.8

### DIFF
--- a/dockerfiles/Dockerfile.python
+++ b/dockerfiles/Dockerfile.python
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7.8-slim
 
 RUN apt-get update && apt-get install -y \
       gettext \

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.7
+python-3.7.8


### PR DESCRIPTION
I was looking at build logs and saw that we can update to python 3.7.8 now (security).