### PR TITLE
Expand subscription creation logging

### DIFF
--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -398,6 +398,10 @@ class MigrateStripeSubscription:
             message = f'Failed to create a Braintree subscription from Stripe subscription {subscription.id}'
             print(message)
             logger.error(message, exc_info=True)
+            logger.error(BT_create_subscription_result.message)
+            # this might not exist
+            if BT_create_subscription_result.errors:
+                logger.error(BT_create_subscription_result.errors)
             return
 
         # Cancel Stripe subscription


### PR DESCRIPTION
We need to get a better idea about why we're seeing these creations fail: https://sentry.prod.mozaws.net/operations/donate-mozilla-org/issues/8432635/events/50349974/

I've added some extra logging based on the documentation I've read about response objects from Braintree here: https://developers.braintreepayments.com/reference/general/result-objects/python