### PR TITLE
Uninstall Wagtail localize

### DIFF
--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -85,12 +85,6 @@ class Base(object):
         'donate.payments',
         'donate.recaptcha',
 
-        'wagtail_localize',
-        'wagtail_localize.admin.language_switch',
-        'wagtail_localize.deprecated.translation_memory',
-        'wagtail_localize.translation',
-        'wagtail_localize_pontoon',
-
         'wagtail.contrib.redirects',
         'wagtail.contrib.settings',
         'wagtail.embeds',

--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,4 @@ sentry-sdk
 stripe
 wagtail
 wagtail-factories
-wagtail-localize
-wagtail-localize-pontoon
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,15 +25,13 @@ django-rq==2.3.2          # via -r requirements.in
 django-storages==1.9.1    # via -r requirements.in
 django-taggit==1.2.0      # via wagtail
 django-treebeard==4.3.1   # via wagtail
-django==2.2.13            # via -r requirements.in, django-csp, django-redis, django-rq, django-storages, django-taggit, django-treebeard, djangorestframework, mozilla-django-oidc, wagtail, wagtail-localize
+django==2.2.13            # via -r requirements.in, django-csp, django-redis, django-rq, django-storages, django-taggit, django-treebeard, djangorestframework, mozilla-django-oidc, wagtail
 djangorestframework==3.11.0  # via wagtail
 docutils==0.15.2          # via botocore
 draftjs-exporter==2.1.7   # via wagtail
 factory-boy==2.12.0       # via -r requirements.in, wagtail-factories
 faker==4.1.0              # via factory-boy
 freezegun==0.3.15         # via -r requirements.in
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.2          # via wagtail-localize-pontoon
 gunicorn==20.0.4          # via -r requirements.in
 html5lib==1.0.1           # via wagtail
 idna==2.9                 # via requests
@@ -41,10 +39,9 @@ jmespath==0.10.0          # via boto3, botocore
 josepy==1.3.0             # via mozilla-django-oidc
 mozilla-django-oidc==1.2.3  # via -r requirements.in
 pillow==6.2.2             # via wagtail
-polib==1.1.0              # via wagtail-localize-pontoon
 psycopg2-binary==2.8.5    # via -r requirements.in
 pycparser==2.20           # via cffi
-pygit2==1.0.3             # via -r requirements.in, wagtail-localize-pontoon
+pygit2==1.0.3             # via -r requirements.in
 pyopenssl==19.1.0         # via josepy
 python-dateutil==2.8.1    # via botocore, faker, freezegun
 pytz==2020.1              # via babel, django, django-modelcluster, wagtail
@@ -55,17 +52,13 @@ rq==1.2.0                 # via -r requirements.in, django-rq
 s3transfer==0.3.3         # via boto3
 sentry-sdk==0.15.1        # via -r requirements.in
 six==1.14.0               # via cryptography, django-configurations, freezegun, html5lib, josepy, mozilla-django-oidc, pyopenssl, python-dateutil, wagtail
-smmap==3.0.4              # via gitdb
 sqlparse==0.3.1           # via django
 stripe==2.48.0            # via -r requirements.in
 text-unidecode==1.3       # via faker
-toml==0.10.1              # via wagtail-localize-pontoon
 unidecode==1.1.1          # via wagtail
 urllib3==1.25.9           # via botocore, requests, sentry-sdk
 wagtail-factories==2.0.0  # via -r requirements.in
-wagtail-localize-pontoon==0.2.1  # via -r requirements.in
-wagtail-localize==0.4     # via -r requirements.in, wagtail-localize-pontoon
-wagtail==2.7.4            # via -r requirements.in, wagtail-factories, wagtail-localize
+wagtail==2.7.4            # via -r requirements.in, wagtail-factories
 webencodings==0.5.1       # via html5lib
 whitenoise==5.1.0         # via -r requirements.in
 willow==1.3               # via wagtail


### PR DESCRIPTION
The latest version of the Wagtail localize package is pretty much a complete rewrite of the version currently in use on donate-wagtail.

Most of the old models are now in Wagtail core and the migrations of the Wagtail localize package have been started from scratch. This means we need to completely unpick the old version before installing the new version.

To do this without any downtime would require multiple deployments:

**1. Delete translated pages**

- Deploy https://github.com/mozilla/donate-wagtail/pull/1213
  - adds a ``delete_translated_pages`` management command
- Run `python manage.py delete_translated_pages`


**2. Remove ``TranslatablePageMixin`` from the models**

- Deploy https://github.com/mozilla/donate-wagtail/pull/1214
  - Removes ``TranslatablePageMixin`` from all the pages
- Run `python manage.py migrate`


**3. Remove Wagtail localize from migration history and delete the tables**

Removing all references to Wagtail localize from the core migrations is required to uninstall the app completely

- Deploy https://github.com/mozilla/donate-wagtail/pull/1215
  - This squashes all of the core migrations and completely removes the ``locale`` foreign keys from history
- Run `python manage.py migrate wagtail_localize zero`
- Run SQL `DELETE FROM django_migrations WHERE app = 'wagtail_localize_pontoon';` \*

**4. Uninstall Wagtail localize**

- Deploy https://github.com/mozilla/donate-wagtail/pull/1216

\* ``wagtail_localize_pontoon | 0001_squashed_0008_new_models`` isn't being removed from Django migration history, despite it being unapplied (in step 3) and the tables removed. Looks like this is a [Django bug](https://code.djangoproject.com/ticket/25255). It should be safe to delete this record from the database manually

---

**Testing**

You can test this process on your local machine my firstly checking out each of the branches, then fetch a database dump (call it `latest.pg`), and then run the following script:

```bash
#!/bin/bash

# Restore database
docker-compose start postgres
PGHOST=127.0.0.1 PGPORT=5678 PGUSER=donate dropdb donate
PGHOST=127.0.0.1 PGPORT=5678 PGUSER=donate createdb donate
cat latest.pg | PGHOST=127.0.0.1 PGPORT=5678 PGUSER=donate pg_restore -d donate
docker-compose stop postgres

# Run test deployment
git checkout remove-translated-pages
docker-compose run --rm backend ./dockerpythonvenv/bin/python manage.py delete_translated_pages
git checkout remove-wagtail-localize
docker-compose run --rm backend ./dockerpythonvenv/bin/python manage.py migrate
git checkout remove-wagtail-localize-from-migration-history
docker-compose run --rm backend ./dockerpythonvenv/bin/python manage.py migrate wagtail_localize zero
PGHOST=127.0.0.1 PGPORT=5678 PGUSER=donate psql -c "DELETE FROM django_migrations WHERE app = 'wagtail_localize_pontoon';"
git checkout uninstall-wagtail-localize
```