### PR TITLE
Changed default values & sorting all presets

### DIFF
--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -53,7 +53,12 @@ class DonationPage(Page):
 
     @cached_property
     def currencies(self):
-        return deepcopy(constants.CURRENCIES)
+        currencies = deepcopy(constants.CURRENCIES)
+        # Re-order currency `single` and `monthly` amounts
+        for currency in currencies:
+            currencies[currency]['presets']['single'].sort()
+            currencies[currency]['presets']['monthly'].sort()
+        return currencies
 
     def get_initial_currency(self, request):
         # Query argument takes first preference
@@ -90,9 +95,7 @@ class DonationPage(Page):
                 ]
                 if amount
             ]
-        except InvalidOperation:
-            return initial_currency_info
-        except ValueError:
+        except (InvalidOperation, ValueError):
             return initial_currency_info
 
         if not custom_presets:

--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -106,9 +106,7 @@ class DonationPage(Page):
 
         sorting = request.GET.get('sort', False)
 
-        if sorting == 'true':
-            custom_presets.sort()
-        elif sorting == 'reverse':
+        if sorting == 'reverse':
             custom_presets.sort(reverse=True)
 
         initial_currency_info['presets'][initial_frequency] = custom_presets[:4]

--- a/donate/core/tests/test_models.py
+++ b/donate/core/tests/test_models.py
@@ -206,17 +206,17 @@ class CampaignPageTestCase(TestCase):
         """
         select the indicated value from our default list of presets (3,15,35,85)
         """
-        request = RequestFactory().get('/?amount=85')
+        request = RequestFactory().get('/?amount=60')
         values = DonationPage().get_initial_values(request)
-        self.assertEqual(values['amount'], Decimal(85).quantize(Decimal('0.01')))
+        self.assertEqual(values['amount'], Decimal(60).quantize(Decimal('0.01')))
 
     def test_select_second_lowest_on_unknown(self):
         """
         default to the second-lowest in (3,15,35,85)
         """
-        request = RequestFactory().get('/?amount=4')
+        request = RequestFactory().get('/?amount=10')
         values = DonationPage().get_initial_values(request)
-        self.assertEqual(values['amount'], Decimal(15).quantize(Decimal('0.01')))
+        self.assertEqual(values['amount'], Decimal(10).quantize(Decimal('0.01')))
 
     def test_select_second_lowest_on_bad_value(self):
         """
@@ -224,7 +224,7 @@ class CampaignPageTestCase(TestCase):
         """
         request = RequestFactory().get('/?amount=not_a_number')
         values = DonationPage().get_initial_values(request)
-        self.assertEqual(values['amount'], Decimal(15).quantize(Decimal('0.01')))
+        self.assertEqual(values['amount'], Decimal(20).quantize(Decimal('0.01')))
 
     def test_ignore_scientific_notation(self):
         """
@@ -232,7 +232,7 @@ class CampaignPageTestCase(TestCase):
         """
         request = RequestFactory().get('/?amount=1e100')
         values = DonationPage().get_initial_values(request)
-        self.assertEqual(values['amount'], Decimal(15).quantize(Decimal('0.01')))
+        self.assertEqual(values['amount'], Decimal(20).quantize(Decimal('0.01')))
 
 
 class MissingMigrationsTests(TestCase):

--- a/donate/core/tests/test_models.py
+++ b/donate/core/tests/test_models.py
@@ -153,13 +153,6 @@ class CampaignPageTestCase(TestCase):
             [Decimal(2), Decimal(9), Decimal(5), Decimal(3)]
         )
 
-    def test_get_initial_currency_info_sorted(self):
-        request = RequestFactory().get('/?presets=2,9,3,5&sort=true')
-        self.assertEqual(
-            DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
-            [Decimal(2), Decimal(3), Decimal(5), Decimal(9)]
-        )
-
     def test_get_initial_currency_info_reverse_sorted(self):
         request = RequestFactory().get('/?presets=2,9,5,3&sort=reverse')
         self.assertEqual(

--- a/donate/payments/constants.py
+++ b/donate/payments/constants.py
@@ -35,8 +35,8 @@ CURRENCIES = {
             {'min': 15, 'value': 3},
         ],
         'presets': {
-            'single': [85, 35, 15, 5],
-            'monthly': [20, 10, 5, 3]
+            'single': [10, 20, 30, 60],
+            'monthly': [5, 10, 15, 20],
         }
     },
     'aud': {
@@ -57,8 +57,8 @@ CURRENCIES = {
             {'min': 22, 'value': 4},
         ],
         'presets': {
-            'single': [30, 15, 7, 4],
-            'monthly': [15, 7, 4, 3]
+            'single': [10, 20, 30, 60],
+            'monthly': [5, 10, 15, 20],
         }
     },
     'brl': {
@@ -101,8 +101,8 @@ CURRENCIES = {
             {'min': 20, 'value': 4},
         ],
         'presets': {
-            'single': [65, 30, 15, 4],
-            'monthly': [10, 7, 4, 3]
+            'single': [10, 20, 30, 60],
+            'monthly': [5, 10, 15, 20],
         }
     },
     'chf': {
@@ -123,8 +123,8 @@ CURRENCIES = {
             {'min': 15, 'value': 3},
         ],
         'presets': {
-            'single': [20, 10, 5, 3],
-            'monthly': [10, 5, 3, 2]
+            'single': [10, 20, 30, 60],
+            'monthly': [5, 10, 15, 20],
         }
     },
     'czk': {
@@ -188,8 +188,8 @@ CURRENCIES = {
             {'min': 32, 'value': 5},
         ],
         'presets': {
-            'single': [85, 35, 15, 5],
-            'monthly': [20, 10, 5, 3]
+            'single': [10, 20, 30, 60],
+            'monthly': [5, 10, 15, 20],
         }
     },
     'gbp': {
@@ -210,8 +210,8 @@ CURRENCIES = {
             {'min': 12, 'value': 3},
         ],
         'presets': {
-            'single': [20, 10, 5, 3],
-            'monthly': [10, 5, 3, 2]
+            'single': [10, 20, 30, 60],
+            'monthly': [5, 10, 15, 20]
         }
     },
     'hkd': {
@@ -362,8 +362,8 @@ CURRENCIES = {
             {'min': 23, 'value': 4},
         ],
         'presets': {
-            'single': [40, 20, 10, 4],
-            'monthly': [20, 10, 8, 3]
+            'single': [10, 20, 30, 60],
+            'monthly': [5, 10, 15, 20]
         }
     },
     'pln': {


### PR DESCRIPTION
Closes #1181 

## Criteria
- [x] 7 main currencies use `10, 20, 30, 60` for single payments. `5, 10, 15, 20` for monthly payments. 
- [x] All preset monthly/single values are sorted from lowest to highest 
- [x] Second lower value is highlighted by default still