### PR TITLE
Update Wagtail Localize Git to 0.9.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,6 +25,6 @@ stripe
 wagtail==2.11.2
 wagtail-factories
 wagtail-localize
-wagtail-localize-git==0.9.1
+wagtail-localize-git==0.9.2
 wagtail-ab-testing==0.1.2
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ urllib3==1.25.9           # via botocore, requests, sentry-sdk
 user-agents==2.2.0        # via wagtail-ab-testing
 wagtail-ab-testing==0.1.2  # via -r requirements.in
 wagtail-factories==2.0.0  # via -r requirements.in
-wagtail-localize-git==0.9.1  # via -r requirements.in
+wagtail-localize-git==0.9.2  # via -r requirements.in
 wagtail-localize==0.9.3   # via -r requirements.in, wagtail-localize-git
 wagtail==2.11.2           # via -r requirements.in, wagtail-ab-testing, wagtail-factories, wagtail-localize, wagtail-localize-git
 webencodings==0.5.1       # via html5lib


### PR DESCRIPTION
To resolve issue with deactivated translations not being removed from Pontoon. https://github.com/wagtail/wagtail-localize-git/pull/11