### PR TITLE
Upgrade Wagtail to 2.11.4

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,35 +4,78 @@
 #
 #    pip-compile dev-requirements.in
 #
-backcall==0.1.0           # via ipython
-certifi==2020.4.5.1       # via -c requirements.txt, requests
-chardet==3.0.4            # via -c requirements.txt, requests
-coverage==5.1             # via coveralls
-coveralls==2.0.0          # via -r dev-requirements.in
-decorator==4.4.2          # via ipython, traitlets
-docopt==0.6.2             # via coveralls
-flake8==3.8.4             # via -r dev-requirements.in
-idna==2.9                 # via -c requirements.txt, requests
-importlib-metadata==1.6.0  # via flake8
-ipython-genutils==0.2.0   # via traitlets
-ipython==7.16.1           # via -r dev-requirements.in
-jedi==0.17.0              # via ipython
-mccabe==0.6.1             # via flake8
-parso==0.7.0              # via jedi
-pexpect==4.8.0            # via ipython
-pickleshare==0.7.5        # via ipython
-prompt-toolkit==3.0.5     # via ipython
-ptvsd==4.3.2              # via -r dev-requirements.in
-ptyprocess==0.6.0         # via pexpect
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
-pygments==2.6.1           # via ipython
-requests==2.24.0          # via -c requirements.txt, coveralls
-six==1.14.0               # via -c requirements.txt, traitlets
-traitlets==4.3.3          # via ipython
-urllib3==1.25.9           # via -c requirements.txt, requests
-wcwidth==0.1.9            # via prompt-toolkit
-zipp==3.1.0               # via importlib-metadata
+backcall==0.1.0
+    # via ipython
+certifi==2020.4.5.1
+    # via
+    #   -c requirements.txt
+    #   requests
+chardet==3.0.4
+    # via
+    #   -c requirements.txt
+    #   requests
+coverage==5.1
+    # via coveralls
+coveralls==2.0.0
+    # via -r dev-requirements.in
+decorator==4.4.2
+    # via
+    #   ipython
+    #   traitlets
+docopt==0.6.2
+    # via coveralls
+flake8==3.8.4
+    # via -r dev-requirements.in
+idna==2.9
+    # via
+    #   -c requirements.txt
+    #   requests
+importlib-metadata==1.6.0
+    # via flake8
+ipython-genutils==0.2.0
+    # via traitlets
+ipython==7.16.1
+    # via -r dev-requirements.in
+jedi==0.17.0
+    # via ipython
+mccabe==0.6.1
+    # via flake8
+parso==0.7.0
+    # via jedi
+pexpect==4.8.0
+    # via ipython
+pickleshare==0.7.5
+    # via ipython
+prompt-toolkit==3.0.5
+    # via ipython
+ptvsd==4.3.2
+    # via -r dev-requirements.in
+ptyprocess==0.6.0
+    # via pexpect
+pycodestyle==2.6.0
+    # via flake8
+pyflakes==2.2.0
+    # via flake8
+pygments==2.6.1
+    # via ipython
+requests==2.24.0
+    # via
+    #   -c requirements.txt
+    #   coveralls
+six==1.14.0
+    # via
+    #   -c requirements.txt
+    #   traitlets
+traitlets==4.3.3
+    # via ipython
+urllib3==1.25.9
+    # via
+    #   -c requirements.txt
+    #   requests
+wcwidth==0.1.9
+    # via prompt-toolkit
+zipp==3.1.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ requests
 rq==1.2.0
 sentry-sdk
 stripe
-wagtail==2.11.2
+wagtail==2.11.4
 wagtail-factories
 wagtail-localize
 wagtail-localize-git==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -215,7 +215,7 @@ wagtail-localize==0.9.3
     # via
     #   -r requirements.in
     #   wagtail-localize-git
-wagtail==2.11.2
+wagtail==2.11.4
     # via
     #   -r requirements.in
     #   wagtail-ab-testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,87 +4,236 @@
 #
 #    pip-compile
 #
-anyascii==0.1.7           # via wagtail
-babel==2.8.0              # via -r requirements.in
-beautifulsoup4==4.8.2     # via wagtail
-boto3==1.14.16            # via -r requirements.in
-botocore==1.17.16         # via boto3, s3transfer
-braintree==4.1.0          # via -r requirements.in
-certifi==2020.4.5.1       # via requests, sentry-sdk
-cffi==1.14.0              # via cryptography, pygit2
-chardet==3.0.4            # via requests
-click==7.1.2              # via rq
-cryptography==2.9.2       # via josepy, mozilla-django-oidc, pyopenssl
-dj-database-url==0.5.0    # via -r requirements.in
-django-configurations==2.2  # via -r requirements.in
-django-countries==6.1.2   # via -r requirements.in
-django-csp==3.6           # via -r requirements.in
-django-environ==0.4.5     # via -r requirements.in
-django-filter==2.4.0      # via wagtail
-django-modelcluster==5.1  # via wagtail
-django-redis==4.12.1      # via -r requirements.in
-django-rq==2.3.2          # via -r requirements.in
-django-storages==1.9.1    # via -r requirements.in
-django-taggit==1.2.0      # via wagtail
-django-treebeard==4.3.1   # via wagtail
-django==2.2.13            # via -r requirements.in, django-csp, django-filter, django-redis, django-rq, django-storages, django-taggit, django-treebeard, djangorestframework, mozilla-django-oidc, wagtail, wagtail-ab-testing, wagtail-localize, wagtail-localize-git
-djangorestframework==3.12.2  # via wagtail
-docutils==0.15.2          # via botocore
-draftjs-exporter==2.1.7   # via wagtail
-et-xmlfile==1.0.1         # via openpyxl
-factory-boy==2.12.0       # via -r requirements.in, wagtail-factories
-faker==4.1.0              # via factory-boy
-freezegun==0.3.15         # via -r requirements.in
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.11         # via wagtail-localize-git
-gunicorn==20.0.4          # via -r requirements.in
-html5lib==1.0.1           # via wagtail
-idna==2.9                 # via requests
-jdcal==1.4.1              # via openpyxl
-jmespath==0.10.0          # via boto3, botocore
-josepy==1.3.0             # via mozilla-django-oidc
-l18n==2020.6.1            # via wagtail
-mozilla-django-oidc==1.2.3  # via -r requirements.in
-numpy==1.19.4             # via scipy, wagtail-ab-testing
-openpyxl==3.0.5           # via tablib
-pillow==6.2.2             # via wagtail
-polib==1.1.0              # via wagtail-localize
-psycopg2-binary==2.8.5    # via -r requirements.in
-pycparser==2.20           # via cffi
-pygit2==1.0.3             # via -r requirements.in, wagtail-localize-git
-pyopenssl==19.1.0         # via josepy
-python-dateutil==2.8.1    # via botocore, faker, freezegun
-pytz==2020.1              # via babel, django, django-modelcluster, l18n
-redis==3.5.1              # via django-redis, django-rq, redlock, rq
-git+git://github.com/glasslion/redlock.git@master#egg=redlock  # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, braintree, mozilla-django-oidc, stripe, wagtail
-rq==1.2.0                 # via -r requirements.in, django-rq
-s3transfer==0.3.3         # via boto3
-scipy==1.5.4              # via wagtail-ab-testing
-sentry-sdk==0.15.1        # via -r requirements.in
-six==1.14.0               # via cryptography, django-configurations, freezegun, html5lib, josepy, l18n, mozilla-django-oidc, pyopenssl, python-dateutil
-smmap==3.0.4              # via gitdb
-soupsieve==2.0.1          # via beautifulsoup4
-sqlparse==0.3.1           # via django
-stripe==2.48.0            # via -r requirements.in
-tablib[xls,xlsx]==2.0.0   # via wagtail
-text-unidecode==1.3       # via faker
-toml==0.10.2              # via wagtail-localize-git
-ua-parser==0.10.0         # via user-agents
-unidecode==1.1.1          # via wagtail
-urllib3==1.25.9           # via botocore, requests, sentry-sdk
-user-agents==2.2.0        # via wagtail-ab-testing
-wagtail-ab-testing==0.1.2  # via -r requirements.in
-wagtail-factories==2.0.0  # via -r requirements.in
-wagtail-localize-git==0.9.2  # via -r requirements.in
-wagtail-localize==0.9.3   # via -r requirements.in, wagtail-localize-git
-wagtail==2.11.2           # via -r requirements.in, wagtail-ab-testing, wagtail-factories, wagtail-localize, wagtail-localize-git
-webencodings==0.5.1       # via html5lib
-whitenoise==5.1.0         # via -r requirements.in
-willow==1.4               # via wagtail
-xlrd==1.2.0               # via tablib
-xlsxwriter==1.3.7         # via wagtail
-xlwt==1.3.0               # via tablib
+anyascii==0.1.7
+    # via wagtail
+babel==2.8.0
+    # via -r requirements.in
+beautifulsoup4==4.8.2
+    # via wagtail
+boto3==1.14.16
+    # via -r requirements.in
+botocore==1.17.16
+    # via
+    #   boto3
+    #   s3transfer
+braintree==4.1.0
+    # via -r requirements.in
+certifi==2020.4.5.1
+    # via
+    #   requests
+    #   sentry-sdk
+cffi==1.14.0
+    # via
+    #   cryptography
+    #   pygit2
+chardet==3.0.4
+    # via requests
+click==7.1.2
+    # via rq
+cryptography==2.9.2
+    # via
+    #   josepy
+    #   mozilla-django-oidc
+    #   pyopenssl
+dj-database-url==0.5.0
+    # via -r requirements.in
+django-configurations==2.2
+    # via -r requirements.in
+django-countries==6.1.2
+    # via -r requirements.in
+django-csp==3.6
+    # via -r requirements.in
+django-environ==0.4.5
+    # via -r requirements.in
+django-filter==2.4.0
+    # via wagtail
+django-modelcluster==5.1
+    # via wagtail
+django-redis==4.12.1
+    # via -r requirements.in
+django-rq==2.3.2
+    # via -r requirements.in
+django-storages==1.9.1
+    # via -r requirements.in
+django-taggit==1.2.0
+    # via wagtail
+django-treebeard==4.3.1
+    # via wagtail
+django==2.2.13
+    # via
+    #   -r requirements.in
+    #   django-csp
+    #   django-filter
+    #   django-redis
+    #   django-rq
+    #   django-storages
+    #   django-taggit
+    #   django-treebeard
+    #   djangorestframework
+    #   mozilla-django-oidc
+    #   wagtail
+    #   wagtail-ab-testing
+    #   wagtail-localize
+    #   wagtail-localize-git
+djangorestframework==3.12.2
+    # via wagtail
+docutils==0.15.2
+    # via botocore
+draftjs-exporter==2.1.7
+    # via wagtail
+et-xmlfile==1.0.1
+    # via openpyxl
+factory-boy==2.12.0
+    # via
+    #   -r requirements.in
+    #   wagtail-factories
+faker==4.1.0
+    # via factory-boy
+freezegun==0.3.15
+    # via -r requirements.in
+gitdb==4.0.5
+    # via gitpython
+gitpython==3.1.11
+    # via wagtail-localize-git
+gunicorn==20.0.4
+    # via -r requirements.in
+html5lib==1.0.1
+    # via wagtail
+idna==2.9
+    # via requests
+jdcal==1.4.1
+    # via openpyxl
+jmespath==0.10.0
+    # via
+    #   boto3
+    #   botocore
+josepy==1.3.0
+    # via mozilla-django-oidc
+l18n==2020.6.1
+    # via wagtail
+mozilla-django-oidc==1.2.3
+    # via -r requirements.in
+numpy==1.19.4
+    # via
+    #   scipy
+    #   wagtail-ab-testing
+openpyxl==3.0.5
+    # via tablib
+pillow==6.2.2
+    # via wagtail
+polib==1.1.0
+    # via wagtail-localize
+psycopg2-binary==2.8.5
+    # via -r requirements.in
+pycparser==2.20
+    # via cffi
+pygit2==1.0.3
+    # via
+    #   -r requirements.in
+    #   wagtail-localize-git
+pyopenssl==19.1.0
+    # via josepy
+python-dateutil==2.8.1
+    # via
+    #   botocore
+    #   faker
+    #   freezegun
+pytz==2020.1
+    # via
+    #   babel
+    #   django
+    #   django-modelcluster
+    #   l18n
+redis==3.5.1
+    # via
+    #   django-redis
+    #   django-rq
+    #   redlock
+    #   rq
+git+git://github.com/glasslion/redlock.git@master#egg=redlock
+    # via -r requirements.in
+requests==2.24.0
+    # via
+    #   -r requirements.in
+    #   braintree
+    #   mozilla-django-oidc
+    #   stripe
+    #   wagtail
+rq==1.2.0
+    # via
+    #   -r requirements.in
+    #   django-rq
+s3transfer==0.3.3
+    # via boto3
+scipy==1.5.4
+    # via wagtail-ab-testing
+sentry-sdk==0.15.1
+    # via -r requirements.in
+six==1.14.0
+    # via
+    #   cryptography
+    #   django-configurations
+    #   freezegun
+    #   html5lib
+    #   josepy
+    #   l18n
+    #   mozilla-django-oidc
+    #   pyopenssl
+    #   python-dateutil
+smmap==3.0.4
+    # via gitdb
+soupsieve==2.0.1
+    # via beautifulsoup4
+sqlparse==0.3.1
+    # via django
+stripe==2.48.0
+    # via -r requirements.in
+tablib[xls,xlsx]==2.0.0
+    # via wagtail
+text-unidecode==1.3
+    # via faker
+toml==0.10.2
+    # via wagtail-localize-git
+ua-parser==0.10.0
+    # via user-agents
+unidecode==1.1.1
+    # via wagtail
+urllib3==1.25.9
+    # via
+    #   botocore
+    #   requests
+    #   sentry-sdk
+user-agents==2.2.0
+    # via wagtail-ab-testing
+wagtail-ab-testing==0.1.2
+    # via -r requirements.in
+wagtail-factories==2.0.0
+    # via -r requirements.in
+wagtail-localize-git==0.9.2
+    # via -r requirements.in
+wagtail-localize==0.9.3
+    # via
+    #   -r requirements.in
+    #   wagtail-localize-git
+wagtail==2.11.2
+    # via
+    #   -r requirements.in
+    #   wagtail-ab-testing
+    #   wagtail-factories
+    #   wagtail-localize
+    #   wagtail-localize-git
+webencodings==0.5.1
+    # via html5lib
+whitenoise==5.1.0
+    # via -r requirements.in
+willow==1.4
+    # via wagtail
+xlrd==1.2.0
+    # via tablib
+xlsxwriter==1.3.7
+    # via wagtail
+xlwt==1.3.0
+    # via tablib
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Closes #1317

Tested locally that it was fixing the draft mode issue for alias pages.

Note on PR: `pip-lock` is using a new format for requirements, so I performed a dry run in a first commit, then a second one with the actual Wagtail version bump to keep the diff readable.