### PR TITLE
Bump wagtail-localize

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -211,7 +211,7 @@ wagtail-factories==2.0.0
     # via -r requirements.in
 wagtail-localize-git==0.9.2
     # via -r requirements.in
-wagtail-localize==0.9.3
+wagtail-localize==0.9.5
     # via
     #   -r requirements.in
     #   wagtail-localize-git


### PR DESCRIPTION
This release contains multiple fixes and improvements.

In particular, it fixes the unlocalized page title on https://give.thunderbird.net/fr, makes richtext links overridable and also adds a Translations report in the reports section.