### PR TITLE
made the update donation amount section inline on desktop

### DIFF
--- a/donate/templates/payment/card_master.html
+++ b/donate/templates/payment/card_master.html
@@ -30,12 +30,12 @@
 
                 <div class="donation-update" data-amount-actions>
                     <form class="donation-update__container" id="js-update-donation-amount-form" data-currency="{{ currency_info.code }}" data-locale="{% get_locale %}">
-                        <div class="donation-update__form-item form-item">
+                        <div class="donation-update__form-item form-item donation-update__amount-input">
                             <label class="donation-update__label form-item__label" for="donation-update">{% trans "Donation Amount" %}</label>
                             <div class="donation-update__currency-symbol">{% get_localized_currency_symbol currency_info.code %}</div>
                             <input class="donation-update__input form-item__input" id="js-update-donation-value" type="number" name="donation-update" value="{{ form.amount.value }}" step="1" min="{{ currency_info.minAmount }}" max="10000000" required>
                         </div>
-                        <div class="form-item">
+                        <div class="form-item donation-update__confirm-button">
                             <button class="donation-update__action button button--primary button--large" id="js-update-button">{% trans 'Confirm' %}</button>
                         </div>
                     </form>

--- a/source/sass/components/_donation-update.scss
+++ b/source/sass/components/_donation-update.scss
@@ -28,19 +28,41 @@
     height: 100%;
     pointer-events: none;
     border-right: 1px solid $color--border;
-    padding: ($gutter * 0.75) ($gutter);
+    padding: ($gutter * 0.8) ($gutter);
     text-align: center;
+    @include media-query(tablet-portrait) {
+      padding: ($gutter * 1.05) ($gutter);
+    }
   }
 
   &__input {
     padding-left: 70px !important; // allow space for currency symbol
+    height: 100%;
   }
 
   &__action {
     width: 100%;
+  }
 
+  &__container {
+    display: block;
+    width: 100%;
     @include media-query(tablet-portrait) {
-      width: auto;
+      display: inline-flex;
+    }
+  }
+
+  &__confirm-button {
+    width: 100%;
+    @include media-query(tablet-portrait) {
+      width: 25%;
+    }
+  }
+  &__amount-input {
+    width: 100%;
+    margin-right: 16px;
+    @include media-query(tablet-portrait) {
+      width: 75%;
     }
   }
 }


### PR DESCRIPTION
Closes #276 

Link to demo site: [here](https://donate-wagta-276-change-8iqpkx.herokuapp.com/en-US/card/single/?source_page_id=3&currency=usd&amount=20)

Steps to test:
1.) Visit site
2.) Click the purple "change amount" link
3.) Notice that a new input and confirm button appear, and are inline. They should appear in a 70/30 format like so: 
<img width="464" alt="image" src="https://user-images.githubusercontent.com/18314510/115939193-33e74480-a452-11eb-84b9-3266d2ed8e0c.png">

4.) Resize screen to mobile width
5.) Note that the inputs are now one on top of the other like so: 
<img width="464" alt="image" src="https://user-images.githubusercontent.com/18314510/115939228-54af9a00-a452-11eb-9629-c9ef2c4e7db3.png">

6.) If they appear like the screenshots above, it is working correctly! Thank you for checking





## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible

