### PR TITLE
Updated how acoustic checked whether or not we are running tests

### DIFF
--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -1,6 +1,6 @@
 import django
 import logging.config
-
+import sys
 from . import defaults
 from .environment import (
     env,
@@ -83,6 +83,9 @@ class Base(object):
     # Pontoon check slack bot
     SLACK_WEBHOOK_PONTOON = env('SLACK_WEBHOOK_PONTOON')
     TRAVIS_LOGS_URL = env('TRAVIS_JOB_WEB_URL', default='')
+
+    # Detect if Django is running normally, or in test mode through "manage.py test"
+    TESTING = 'test' in sys.argv
 
     @property
     def CSRF_TRUSTED_ORIGINS(self):

--- a/donate/settings/testing.py
+++ b/donate/settings/testing.py
@@ -9,7 +9,6 @@ from .braintree import Braintree
 
 class Testing(Base, Secure, Redis, OIDC, Database, Braintree, Configuration):
     SECRET_KEY = 'test'
-    IS_TESTING = True
     RECAPTCHA_ENABLED = False
     RECAPTCHA_SITE_KEY = 'test'
     RECAPTCHA_SECRET_KEY = 'test'

--- a/donate/utility/acoustic/acoustic.py
+++ b/donate/utility/acoustic/acoustic.py
@@ -10,8 +10,6 @@ from silverpop.api import Silverpop, SilverpopResponseException
 
 logger = logging.getLogger(__name__)
 XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-# Checking whether or not we are running tests
-TESTING = settings.TESTING
 
 
 def process_response(resp):
@@ -117,7 +115,7 @@ class AcousticTransact(Silverpop):
 
     def send_mail(self, to, campaign_id, fields=None, bcc=None, save_to_db=False):
         # If we are testing, do not send emails
-        if not TESTING:
+        if not settings.TESTING:
             self._call_xt(transact_xml(to, campaign_id, fields, bcc, save_to_db))
 
 

--- a/donate/utility/acoustic/acoustic.py
+++ b/donate/utility/acoustic/acoustic.py
@@ -10,6 +10,8 @@ from silverpop.api import Silverpop, SilverpopResponseException
 
 logger = logging.getLogger(__name__)
 XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+# Checking whether or not we are running tests
+TESTING = settings.TESTING
 
 
 def process_response(resp):
@@ -115,7 +117,7 @@ class AcousticTransact(Silverpop):
 
     def send_mail(self, to, campaign_id, fields=None, bcc=None, save_to_db=False):
         # If we are testing, do not send emails
-        if not hasattr(settings, "IS_TESTING"):
+        if not TESTING:
             self._call_xt(transact_xml(to, campaign_id, fields, bcc, save_to_db))
 
 


### PR DESCRIPTION
Closes #1407 

Instead of adding a ENV variable called "IS_TESTING", we are now using the "TESTING" flag which is in the app's settings.
If the application is running its tests, emails will not be sent through acoustic, however if the app is deployed it will send emails through acoustic. 

## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible]

