### PR TITLE
[1418] build and deploy web to case form for donate

### DIFF
--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -319,6 +319,5 @@ class ContributorSupportPage(Page):
         ctx.update({
             'orgid': settings.SALESFORCE_ORGID,
             'record_type_id': settings.SALESFORCE_CASE_RECORD_TYPE_ID,
-            'salesforce_form_url': settings.SALESFORCE_FORM_URL,
         })
         return ctx

--- a/donate/settings/environment.py
+++ b/donate/settings/environment.py
@@ -66,7 +66,6 @@ env = environ.Env(
     REDIS_URL=(str, 'redis://redis:6397/0'),
     REVIEW_APP=(bool, False),
     SALESFORCE_ORGID=(str, ''),
-    SALESFORCE_FORM_URL=(str, ''),
     SALESFORCE_CASE_RECORD_TYPE_ID=(str, ''),
     SENTRY_DSN=(str, None),
     SENTRY_ENVIRONMENT=(str, None),

--- a/donate/settings/salesforce.py
+++ b/donate/settings/salesforce.py
@@ -3,5 +3,4 @@ from .environment import env
 
 class Salesforce(object):
     SALESFORCE_ORGID = env('SALESFORCE_ORGID')
-    SALESFORCE_FORM_URL = env('SALESFORCE_FORM_URL')
     SALESFORCE_CASE_RECORD_TYPE_ID = env('SALESFORCE_CASE_RECORD_TYPE_ID')

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -1,6 +1,11 @@
 {% extends "pages/base_page.html" %}
 {% load form_tags static wagtailcore_tags wagtailimages_tags i18n %}
 
+{% block meta_tags %}
+    {{ block.super }}
+    <meta http-equiv="Content-type" content="text/html; charset=UTF-8">
+{% endblock %}
+
 {% block content %}
 
 <header class="page-header">
@@ -24,7 +29,7 @@
                     <p class="rich-text">{% trans "We will get back to you soon." %}</p>
                 </div>
             {% else %}
-                <form class="" action="{{ salesforce_form_url }}" method="POST">
+                <form class="" action="https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8" method="POST">
                     <p class="rich-text">{% blocktrans trimmed %}
                     If you need help with a contribution to MZLA/Thunderbird, please fill out this form and a Thunderbird donor care representative will get back to you as soon as possible.
                     {% endblocktrans %}</p>
@@ -33,11 +38,11 @@
                     Unfortunately, donor care representatives are unable to offer support or help with Thunderbird technical issues. For technical support, please visit our <a href="{{ support_url }}">support page.</a>
                     {% endblocktrans %}</p>
 
-                    <input type=hidden name="orgid" value="{{ orgid }}">
-                    <input type=hidden name="retURL" value="{{ page.get_full_url }}?submitted=true">
+                    <input type="hidden" name="orgid" value="{{ orgid }}">
+                    <input type="hidden" name="retURL" value="{{ page.get_full_url }}?submitted=true">
 
                     {% block custom_hidden_fields %}
-                        <input type=hidden name="type" value="Donation">
+                        <input type="hidden" name="type" value="Donation">
                     {% endblock %}
 
                     <fieldset class="form-item">
@@ -51,9 +56,9 @@
                     </fieldset>
 
                     <fieldset class="form-item">
-                        <label for="00N0B000006X3fw">{% trans "Language" %}</label>
+                        <label for="00N4x00000O6Pzw">{% trans "Language" %}</label>
                         <div class="form-item__wrapper form-custom-select">
-                            <select id="00N0B000006X3fw" name="00N0B000006X3fw" title="Language">
+                            <select id="00N4x00000O6Pzw" name="00N4x00000O6Pzw" title="Language">
                                 <option value="">--{% trans "None" context "Option in 'Language' dropdown" %}--</option>
                                 <option value="English">{% trans "English" %}</option>
                                 <option value="French">{% trans "French" %}</option>

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -7,6 +7,7 @@
 {% endblock %}
 
 {% block content %}
+{% wagtail_site as current_site %}
 
 <header class="page-header">
     <div class="page-header__container">
@@ -34,9 +35,11 @@
                     If you need help with a contribution to MZLA/Thunderbird, please fill out this form and a Thunderbird donor care representative will get back to you as soon as possible.
                     {% endblocktrans %}</p>
 
-                    <p class="rich-text">{% blocktrans with support_url="https://support.mozilla.org/products/thunderbird/" trimmed %}
-                    Unfortunately, donor care representatives are unable to offer support or help with Thunderbird technical issues. For technical support, please visit our <a href="{{ support_url }}">support page.</a>
-                    {% endblocktrans %}</p>
+                    {% if 'thunderbird' in current_site.hostname %}
+                        <p class="rich-text">{% blocktrans with support_url="https://support.mozilla.org/products/thunderbird/" trimmed %}
+                        Unfortunately, donor care representatives are unable to offer support or help with Thunderbird technical issues. For technical support, please visit our <a href="{{ support_url }}">support page.</a>
+                        {% endblocktrans %}</p>
+                    {% endif %}
 
                     <input type="hidden" name="orgid" value="{{ orgid }}">
                     <input type="hidden" name="retURL" value="{{ page.get_full_url }}?submitted=true">

--- a/donate/thunderbird/templates/pages/core/contributor_support_page.html
+++ b/donate/thunderbird/templates/pages/core/contributor_support_page.html
@@ -1,6 +1,6 @@
 {% extends "pages/core/contributor_support_page_master.html" %}
 
 {% block custom_hidden_fields %}
-    <input type=hidden name="recordType" id="recordType" value="{{record_type_id}}">
-    <input type=hidden name="type" value="Thunderbird">
+    <input type="hidden" name="recordType" id="recordType" value="{{record_type_id}}">
+    <input type="hidden" name="type" value="Thunderbird">
 {% endblock %}


### PR DESCRIPTION
Closes #1418 

Testing
* Go to https://thunderbird-1418-build--i9mdda.herokuapp.com/en-US/help/ 
  * This link should show 2 paragraphs above the form and the form should submit fine. ![image](https://user-images.githubusercontent.com/4743971/117022497-8677fa80-acb5-11eb-87d2-b65b02477a68.png)

  * You'll receive an email when it goes through from Mozilla snfp. 


I'll leave comments from a self-review for additional context. 

On approval, for staging and prod:
- [ ] Delete `SALESFORCE_FORM_URL` env var. 
- [ ] Change the production thunderbird env vars for SALESFORCE_ORGID and SALESFORCE_CASE_RECORD_TYPE_ID
- [ ] Double check CSP_FORM_ACTION is set