### PR TITLE
Text changes for Donate vs. Thunderbird

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ More information on how to use Docker for local dev is available in the [Local d
 | ThunderbirdProduction | Production configuration for Thunderbird donation configurations.                                                  |
 | ThunderbirdReviewApp  | Review App configuration for Thunderbird donation configurations.                                                  |
 
-
+To set the Thunderbird settings in local development, simply change your `DJANGO_CONFIGURATION` in your .env file to be one of the choices above (For Thunderbird, use `ThunderbirdDevelopment`)
 
 
 ## Braintree configuration

--- a/donate/templates/fragments/donate_form_disclaimer_master.html
+++ b/donate/templates/fragments/donate_form_disclaimer_master.html
@@ -20,8 +20,8 @@
     </p>
     <p>
         {% block faq_contact %}
-        {% blocktrans with faq_url='/faq' trimmed %}
-            Problems donating? Visit our <a href="{{ faq_url }}">FAQ</a> for answers to most common questions. Still have problems? <a href="/help/">Contact us</a>.
+        {% blocktrans with faq_url='/faq' help_url='/help/' trimmed %}
+            Problems donating? Visit our <a href="{{ faq_url }}">FAQ</a> for answers to most common questions. Still have problems? <a href="{{ help_url }}">Contact us</a>.
         {% endblocktrans %}
         {% endblock %}
     </p>

--- a/donate/templates/fragments/donate_form_disclaimer_master.html
+++ b/donate/templates/fragments/donate_form_disclaimer_master.html
@@ -20,8 +20,8 @@
     </p>
     <p>
         {% block faq_contact %}
-        {% blocktrans with faq_url='/faq' email='donate@mozilla.org' trimmed %}
-            Problems donating? Visit our <a href="{{ faq_url }}">FAQ</a> for answers to most common questions. Still have problems? <a href="mailto:{{ email }}">Send us an email</a>.
+        {% blocktrans with faq_url='/faq' trimmed %}
+            Problems donating? Visit our <a href="{{ faq_url }}">FAQ</a> for answers to most common questions. Still have problems? <a href="/help/">Contact us</a>.
         {% endblocktrans %}
         {% endblock %}
     </p>

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -34,7 +34,7 @@
 
                     {% block donate_support_text %}
                         <p class="rich-text">
-                            {% blocktrans with support_url="https://support.mozilla.org/products/thunderbird/" trimmed %}
+                            {% blocktrans trimmed %}
                                 If you need help with a donation to the Mozilla Foundation, please fill out this form and a donor care representative will get back to you as soon as possible.
                             {% endblocktrans %}
                         </p>

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -31,15 +31,14 @@
                 </div>
             {% else %}
                 <form class="" action="https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8" method="POST">
-                    <p class="rich-text">{% blocktrans trimmed %}
-                    If you need help with a contribution to MZLA/Thunderbird, please fill out this form and a Thunderbird donor care representative will get back to you as soon as possible.
-                    {% endblocktrans %}</p>
 
-                    {% if 'thunderbird' in current_site.hostname %}
-                        <p class="rich-text">{% blocktrans with support_url="https://support.mozilla.org/products/thunderbird/" trimmed %}
-                        Unfortunately, donor care representatives are unable to offer support or help with Thunderbird technical issues. For technical support, please visit our <a href="{{ support_url }}">support page.</a>
-                        {% endblocktrans %}</p>
-                    {% endif %}
+                    {% block donate_support_text %}
+                        <p class="rich-text">
+                            {% blocktrans with support_url="https://support.mozilla.org/products/thunderbird/" trimmed %}
+                                If you need help with a donation to the Mozilla Foundation, please fill out this form and a donor care representative will get back to you as soon as possible.
+                            {% endblocktrans %}
+                        </p>
+                    {% endblock %}
 
                     <input type="hidden" name="orgid" value="{{ orgid }}">
                     <input type="hidden" name="retURL" value="{{ page.get_full_url }}?submitted=true">

--- a/donate/thunderbird/templates/pages/core/contributor_support_page.html
+++ b/donate/thunderbird/templates/pages/core/contributor_support_page.html
@@ -1,5 +1,5 @@
 {% extends "pages/core/contributor_support_page_master.html" %}
-
+{% load i18n %}
 
 {% block donate_support_text %}
     <p class="rich-text">

--- a/donate/thunderbird/templates/pages/core/contributor_support_page.html
+++ b/donate/thunderbird/templates/pages/core/contributor_support_page.html
@@ -1,5 +1,20 @@
 {% extends "pages/core/contributor_support_page_master.html" %}
 
+
+{% block donate_support_text %}
+    <p class="rich-text">
+        {% blocktrans trimmed %}
+            If you need help with a contribution to MZLA/Thunderbird, please fill out this form and a Thunderbird donor care representative will get back to you as soon as possible.
+        {% endblocktrans %}
+    </p>
+
+    <p class="rich-text">
+        {% blocktrans with support_url="https://support.mozilla.org/products/thunderbird/" trimmed %}
+            Unfortunately, donor care representatives are unable to offer support or help with Thunderbird technical issues. For technical support, please visit our <a href="{{ support_url }}">support page.</a>
+        {% endblocktrans %}
+    </p>
+{% endblock %}
+
 {% block custom_hidden_fields %}
     <input type="hidden" name="recordType" id="recordType" value="{{record_type_id}}">
     <input type="hidden" name="type" value="Thunderbird">


### PR DESCRIPTION
Closes #1425 

Donate help page:
https://donate-wagta-1425-creat-beirmh.herokuapp.com/en-US/help/
Donate contact link update:
https://donate-wagta-1425-creat-beirmh.herokuapp.com/en-US/
Thunderbird help page:
https://thunderbird-1425-create-9yetke.herokuapp.com/en-US/help/


## Acceptance criteria: 
- [x] Update "Send us an email." text on https://donate.mozilla.org/ template to "Contact us." which would link to a new form page.
- [x] Create a new form page at https://donate.mozilla.org/help/ which would be similar to https://give.thunderbird.net/help but the intro copy could say:
> If you need help with a donation to the Mozilla Foundation, please fill out this form and a donor care representative will get back to you as soon as possible.
- [x] Make this template the Mozilla one (adding the intro above) https://github.com/mozilla/donate-wagtail/tree/master/donate/templates/pages/core/contributor_support_page_master.html and move the TB specific copy to https://github.com/mozilla/donate-wagtail/tree/master/donate/thunderbird/templates/pages/core/contributor_support_page.html as overrides
- [x] Make sure the /help/ page exists in production
- [x] Make sure to use a different Salesforce Form IDs for Thunderbird and Donate (@stephaniemcv to provide a dedicated ID) (Applied in #1434) 
- [ ] Edit questions on https://donate.mozilla.org/en-US/faq/ to replace donate@mozilla.org with the form. (Théo can do, with a review from @WillatMozFdn)
- [ ] Localize CMS updates (Théo)
- [ ] Localize template updates (Théo)