### PR TITLE
Text update

### DIFF
--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -38,6 +38,11 @@
                                 If you need help with a donation to the Mozilla Foundation, please fill out this form and a donor care representative will get back to you as soon as possible.
                             {% endblocktrans %}
                         </p>
+                        <p class="rich-text">
+                            {% blocktrans trimmed %}
+                                Unfortunately, donor care representatives are unable to offer support or help with Firefox technical issues.
+                            {% endblocktrans %}
+                        </p>
                     {% endblock %}
 
                     <input type="hidden" name="orgid" value="{{ orgid }}">


### PR DESCRIPTION
Closes #1425 

**Example page**: https://donate-wagta-1425-donat-ke7uxg.herokuapp.com/en-US/help/

This is a second PR to further update help text on the Mozilla Donate site. 