### PR TITLE
Hotfix: Added recordTypes for thunderbird and development

### DIFF
--- a/donate/settings/development.py
+++ b/donate/settings/development.py
@@ -14,6 +14,7 @@ from .thunderbird import ThunderbirdOverrides
 class Development(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree, Configuration):
     DEBUG = env('DEBUG')
     DJANGO_LOG_LEVEL = env('DJANGO_LOG_LEVEL')
+    SALESFORCE_CASE_RECORD_TYPE_ID = "0124x000000A1ez"
 
     RECAPTCHA_ENABLED = False
     SECURE_SSL_REDIRECT = False
@@ -42,6 +43,7 @@ class ThunderbirdDevelopment(Development, ThunderbirdOverrides, Configuration):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Development.INSTALLED_APPS
     FRONTEND = ThunderbirdOverrides.FRONTEND
     ENABLE_THUNDERBIRD_REDIRECT = False
+    SALESFORCE_CASE_RECORD_TYPE_ID = "0124x000000A2Pl"
     FRAUD_SITE_ID = 'tbird'
 
     @property

--- a/donate/settings/production.py
+++ b/donate/settings/production.py
@@ -13,6 +13,7 @@ from .thunderbird import ThunderbirdOverrides
 
 class Production(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree, Sentry, Configuration):
     DEBUG = False
+    SALESFORCE_CASE_RECORD_TYPE_ID = "0124x000000A1ez"
 
     @classmethod
     def pre_setup(cls):
@@ -34,7 +35,7 @@ class ThunderbirdProduction(Production, ThunderbirdOverrides, Configuration):
     INSTALLED_APPS = ThunderbirdOverrides.INSTALLED_APPS + Production.INSTALLED_APPS
     FRONTEND = ThunderbirdOverrides.FRONTEND
     ENABLE_THUNDERBIRD_REDIRECT = False
-    SALESFORCE_CASE_RECORD_TYPE_ID = "0124O000000tDBO"
+    SALESFORCE_CASE_RECORD_TYPE_ID = "0124x000000A2Pl"
     FRAUD_SITE_ID = 'tbird'
 
     @property

--- a/donate/settings/staging.py
+++ b/donate/settings/staging.py
@@ -13,6 +13,7 @@ from .thunderbird import ThunderbirdOverrides
 
 class Staging(Base, Secure, OIDC, Database, Redis, S3, Salesforce, Braintree, Sentry, Configuration):
     DEBUG = False
+    SALESFORCE_CASE_RECORD_TYPE_ID = "0124x000000A1ez"
 
     @classmethod
     def pre_setup(cls):
@@ -34,6 +35,7 @@ class ThunderbirdStaging(Staging, ThunderbirdOverrides, Configuration):
     FRONTEND = ThunderbirdOverrides.FRONTEND
     ENABLE_THUNDERBIRD_REDIRECT = False
     FRAUD_SITE_ID = 'tbird'
+    SALESFORCE_CASE_RECORD_TYPE_ID = "0124x000000A2Pl"
 
     @property
     def TEMPLATES(self):

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -50,6 +50,7 @@
 
                     {% block custom_hidden_fields %}
                         <input type="hidden" name="type" value="Donation">
+                        <input type="hidden" name="recordType" id="recordType" value="{{record_type_id}}">
                     {% endblock %}
 
                     <fieldset class="form-item">


### PR DESCRIPTION
Added recordTypes for development and production in both thunderbird and donate. 

No need for env vars since these are publicly exposed in the template when it's rendered. 