### PR TITLE
removing recurring from donation_receipt_fields

### DIFF
--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -56,7 +56,6 @@ DONATION_RECEIPT_FIELDS = [
     "email",
     "first_name",
     "last_name",
-    "recurring",
     "transaction_id",
     "card_type",
     "last_4",


### PR DESCRIPTION
Closes #1466 

It turns out we were sending "recurring" to acoustic in line 111-113, this causes an error as acoustic is not expecting a bool. 
So now what we are doing is checking if donation_data includes "recurring" as true, if so, we are sending "recurring" as the subject line, if not, we are saying "one-time"

## Checklist


**Changes in Models:**
- [x]  [Are my changes backward-compatible]
