### PR TITLE
Use separate redis instance for queues

### DIFF
--- a/donate/settings/environment.py
+++ b/donate/settings/environment.py
@@ -64,6 +64,7 @@ env = environ.Env(
     RECAPTCHA_SECRET_KEY=(str, ''),
     RECAPTCHA_SITE_KEY=(str, ''),
     REDIS_URL=(str, 'redis://redis:6397/0'),
+    REDIS_QUEUE_URL=(str, 'redis://redis:6397/0'),
     REVIEW_APP=(bool, False),
     SALESFORCE_ORGID=(str, ''),
     SALESFORCE_CASE_RECORD_TYPE_ID=(str, ''),

--- a/donate/settings/redis.py
+++ b/donate/settings/redis.py
@@ -19,12 +19,12 @@ class Redis(object):
 
     RQ_QUEUES = {
         'default': {
-            'URL': env('REDIS_URL'),
+            'URL': env('REDIS_QUEUE_URL'),
             'DEFAULT_TIMEOUT': 500
         },
         # Must be a separate queue as it's limited to one item at a time
         'wagtail_localize_pontoon.sync': {
-            'URL': env('REDIS_URL'),
+            'URL': env('REDIS_QUEUE_URL'),
             'DEFAULT_TIMEOUT': 500
         }
     }


### PR DESCRIPTION
So that we can use a redis instance with an `allkeys-lru` expiry policy for cache to prevent OOM errors.