### PR TITLE
Message id key error fix

### DIFF
--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -1,3 +1,4 @@
+from donate.settings import languages
 import logging
 import time
 from decimal import Decimal
@@ -17,7 +18,6 @@ from .utils import (
     get_plan_id,
     get_merchant_account_id_for_card
 )
-from ..settings.languages import LANGUAGE_IDS
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,8 @@ DONATION_RECEIPT_FIELDS_MAP = {
     "locale": "donation_locale",
     "service": "payment_source",
 }
+
+LANGUAGE_IDS = languages.LANGUAGE_IDS
 
 
 # Acoustic receipt sending

--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -1,4 +1,3 @@
-from donate.settings import languages
 import logging
 import time
 from decimal import Decimal
@@ -73,7 +72,7 @@ DONATION_RECEIPT_FIELDS_MAP = {
     "service": "payment_source",
 }
 
-LANGUAGE_IDS = languages.LANGUAGE_IDS
+LANGUAGE_IDS = settings.LANGUAGE_IDS
 
 
 # Acoustic receipt sending

--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -56,7 +56,6 @@ DONATION_RECEIPT_FIELDS = [
     "email",
     "first_name",
     "last_name",
-    "recurring",
     "transaction_id",
     "card_type",
     "last_4",

--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -8,7 +8,7 @@ from .environment import (
     root
 )
 
-from .languages import LANGUAGES
+from .languages import LANGUAGES, LANGUAGE_IDS
 
 
 class Base(object):
@@ -16,6 +16,7 @@ class Base(object):
     WAGTAIL_SITE_NAME = 'donate'
     WSGI_APPLICATION = 'donate.wsgi.application'
     LANGUAGE_CODE = 'en-US'
+    DEFAULT_LANGUAGE_ID = LANGUAGE_IDS[LANGUAGE_CODE]
     TIME_ZONE = 'UTC'
     USE_I18N = True
     USE_L10N = True

--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -16,6 +16,7 @@ class Base(object):
     WAGTAIL_SITE_NAME = 'donate'
     WSGI_APPLICATION = 'donate.wsgi.application'
     LANGUAGE_CODE = 'en-US'
+    LANGUAGE_IDS = LANGUAGE_IDS
     DEFAULT_LANGUAGE_ID = LANGUAGE_IDS[LANGUAGE_CODE]
     TIME_ZONE = 'UTC'
     USE_I18N = True

--- a/donate/settings/languages.py
+++ b/donate/settings/languages.py
@@ -65,3 +65,16 @@ LANGUAGES = [
     ('zh-CN', 'Chinese (China)'),
     ('zh-TW', 'Chinese (Taiwan)'),
 ]
+
+# Collection of different language email templates,
+# for receipt sending through acoustic in payments/tasks.py.
+LANGUAGE_IDS = {
+    "ja": "1621701",
+    "pl": "1621706",
+    "pt-BR": "1621708",
+    "cs": "1621689",
+    "de": "1621691",
+    "es": "1621695",
+    "fr": "1621697",
+    "en-US": "1621694",
+}


### PR DESCRIPTION
Closes #1482 

We are now setting a default email language id in base.py, and if the app is not able to find a language it will immediately prevent the app from running. 

I also updated the function to use single quotes instead of double quotes. 

## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/master/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

