### PR TITLE
updated "service" to "payment method" in process_donation_receipt

### DIFF
--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -80,8 +80,7 @@ def process_donation_receipt(donation_data):
     # Creating new object by looping through mandatory receipt fields from const dictionary,
     # and updating them to equal the data being received
     message_data = {k: v for k, v in donation_data.items() if k in DONATION_RECEIPT_FIELDS}
-    email = "daniel@mozillafoundation.org"
-    # email = message_data.pop('email')
+    email = message_data.pop('email')
     # If the donation data did not recieve a payment time, use the current time.
     created = message_data.get('created', int(time.time()))
     # The next 3 lines are formatting the date and time for the email

--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -60,8 +60,8 @@ DONATION_RECEIPT_FIELDS = [
     "card_type",
     "last_4",
     "locale",
-    "service",
     "project",
+    "payment_method"
 ]
 
 # map of incoming donation data field names -> email/acoustic field names
@@ -69,7 +69,7 @@ DONATION_RECEIPT_FIELDS_MAP = {
     "card_type": "cc_type",
     "last_4": "cc_last_4_digits",
     "locale": "donation_locale",
-    "service": "payment_source",
+    "payment_method": "payment_source",
 }
 
 LANGUAGE_IDS = settings.LANGUAGE_IDS
@@ -80,7 +80,8 @@ def process_donation_receipt(donation_data):
     # Creating new object by looping through mandatory receipt fields from const dictionary,
     # and updating them to equal the data being received
     message_data = {k: v for k, v in donation_data.items() if k in DONATION_RECEIPT_FIELDS}
-    email = message_data.pop('email')
+    email = "daniel@mozillafoundation.org"
+    # email = message_data.pop('email')
     # If the donation data did not recieve a payment time, use the current time.
     created = message_data.get('created', int(time.time()))
     # The next 3 lines are formatting the date and time for the email

--- a/donate/payments/tasks.py
+++ b/donate/payments/tasks.py
@@ -96,7 +96,7 @@ def process_donation_receipt(donation_data):
         'MZLA Thunderbird' if message_data['project'] == 'thunderbird' else 'Mozilla'
     )
 
-    # convert some field names to match Acoustic API by looping through dict
+    # convert some field names to match Acoustic API email fields by looping through dict
     # and updating fields that match
     send_data = {
         DONATION_RECEIPT_FIELDS_MAP.get(k, k): v for k, v in message_data.items()


### PR DESCRIPTION
Closes #1505 

It turns out the email function was looking for something with the key of "payment_method" but we were sending it "service". After making this change in the email function, the emails now differentiate between paypal payments and credit card payments! 

## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/master/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

