### PR TITLE
Convert "Visit thank you page" goal into a global A/B testing event and trigger it from the frontend

### DIFF
--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -16,9 +16,6 @@ import mailchimp_marketing as MailchimpMarketing
 from mailchimp_marketing.api_client import ApiClientError
 from dateutil.relativedelta import relativedelta
 from wagtail.core.models import Page
-from wagtail_ab_testing.models import AbTest
-from wagtail_ab_testing.utils import request_is_trackable
-
 
 from donate.core.utils import queue_ga_event
 from . import constants, gateway
@@ -832,23 +829,5 @@ class NewsletterSignupView(TransactionRequiredMixin, FormView):
         return super().form_valid(form)
 
 
-class ThankYouView(TransactionRequiredMixin, TemplateView):
+class ThankYouView(TemplateView):
     template_name = 'payment/thank_you.html'
-
-    def get(self, *args, **kwargs):
-        # Check if the user is trackable
-        if request_is_trackable(self.request):
-            for test in AbTest.objects.filter(goal_event='visit-thank-you-page', status=AbTest.STATUS_RUNNING):
-                # Is the user a participant in this test?
-                if f'wagtail-ab-testing_{test.id}_version' not in self.request.session:
-                    continue
-
-                # Has the user already completed the test?
-                if f'wagtail-ab-testing_{test.id}_completed' in self.request.session:
-                    continue
-
-                # Log a conversion
-                test.log_conversion(self.request.session[f'wagtail-ab-testing_{test.id}_version'])
-                self.request.session[f'wagtail-ab-testing_{test.id}_completed'] = 'yes'
-
-        return super().get(*args, **kwargs)

--- a/donate/payments/wagtail_hooks.py
+++ b/donate/payments/wagtail_hooks.py
@@ -1,13 +1,10 @@
 from wagtail.core import hooks
 from wagtail_ab_testing.events import BaseEvent
-from donate.core.models import LandingPage
 
 
 class VisitThankYouPageEvent(BaseEvent):
     name = "Visit the thank you page"
-
-    def get_page_types(self):
-        return [LandingPage]
+    requires_page = False
 
 
 @hooks.register('register_ab_testing_event_types')

--- a/donate/templates/payment/card_upsell_master.html
+++ b/donate/templates/payment/card_upsell_master.html
@@ -63,3 +63,8 @@
 </div>
 
 {% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "./includes/trigger_ab_testing_thank_you_event.html" %}
+{% endblock %}

--- a/donate/templates/payment/includes/trigger_ab_testing_thank_you_event.html
+++ b/donate/templates/payment/includes/trigger_ab_testing_thank_you_event.html
@@ -1,0 +1,10 @@
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Need to setTimeout to make sure the A/B testing library is loaded
+        setTimeout(function() {
+            if (window.wagtailAbTesting) {
+                window.wagtailAbTesting.triggerEvent('visit-thank-you-page');
+            }
+        }, 1000);
+    });
+</script>

--- a/donate/templates/payment/thank_you_master.html
+++ b/donate/templates/payment/thank_you_master.html
@@ -63,3 +63,8 @@
     </div>
 </div>
 {% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "./includes/trigger_ab_testing_thank_you_event.html" %}
+{% endblock %}

--- a/requirements.in
+++ b/requirements.in
@@ -30,6 +30,6 @@ wagtail==2.11.4
 wagtail-factories
 wagtail-localize
 wagtail-localize-git==0.9.2
-wagtail-ab-testing==0.3.1
+wagtail-ab-testing==0.4
 whitenoise
 scout-apm

--- a/requirements.txt
+++ b/requirements.txt
@@ -249,7 +249,7 @@ wagtail==2.11.4
     #   wagtail-factories
     #   wagtail-localize
     #   wagtail-localize-git
-wagtail-ab-testing==0.3.1
+wagtail-ab-testing==0.4
     # via -r requirements.in
 wagtail-factories==2.0.0
     # via -r requirements.in


### PR DESCRIPTION
When we moved the tracking logic into the frontend in the 0.3 update, this event stopped working. This is because we are no longer tracking participation with cookies, which this event relied on, it now uses a JS tracking library that stores state in ``localStorage`` instead.

This PR moves the tracking code for this event type into the frontend. It also converts it into a global event, since the thank you view is not a page, so the new frontend tracker would ignore it. This requires another update of the Wagtail A/B testing package as global event's weren't supported before.