### PR TITLE
updated thank you text for mozilla donate, to link to the /help/ page.

### DIFF
--- a/donate/templates/payment/thank_you_master.html
+++ b/donate/templates/payment/thank_you_master.html
@@ -12,8 +12,7 @@
             <h1 class="heading heading--primary heading--bottom-margin">{% trans "Thank you for your generous gift" %}</h1>
 
             {% block thank_you_description %}
-                <p>{% blocktrans %}Your donation will go right to work protecting the web, keeping it open and available to all.{% endblocktrans %} {% blocktrans with email='donate@mozilla.org' %}We’ve emailed you a donation receipt; if it’s missing, please check your junk/spam folders, then contact us at <a href="mailto:{{ email }}">{{ email }}</a>.{% endblocktrans %}</p>
-
+                <p>{% blocktrans with url='/help' %}We’ve emailed you a donation receipt; if it’s missing, please check your junk/spam folders, then contact us using <a href="{{ url }}">this form</a>.{% endblocktrans %}</p>
                 <p>{% trans "Lastly, can you multiply your impact by sharing about the important work Mozilla is doing? Thank you again!" %}</p>
             {% endblock %}
 


### PR DESCRIPTION
Closes #1526 

## Testing

**Steps to test:**

1. Visit [testing site](https://donate-wagta-1526-help--wjwpze.herokuapp.com/en-US/)
2. Click the purple credit card payment button
3. Fill out the form with the test card information below
4. Once you reach the thank you page after submitting the form, click through until the 4 share buttons show up.
5. Click the purple "This Form" link, and it should redirect you to /help/. Please note however, that the link will be broken since it is a review app
6. If working, testing is complete! 

**Testing Credit Card Info:**
Card Number: 4111 1111 1111 1111
EXP: 12/23
CVV: 123

## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible]
