### PR TITLE
Countries without post-codes now working

### DIFF
--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -18,7 +18,7 @@ import json
 # # Loading a JSON list of countries and their respective post code formats if applicable,
 # # from the source/js directory.
 try:
-    with open('../source/js/components/post-codes-list.json') as post_code_data:
+    with open('/app/source/js/components/post-codes-list.json') as post_code_data:
         COUNTRY_POST_CODES = json.load(post_code_data)
 except Exception as error:
     print('ERROR: could not read in post codes list')

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -16,6 +16,9 @@ from .utils import get_currency_info
 from ..settings.environment import root
 
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 # Loading a JSON list of countries and their respective post code formats if applicable,
 # from the source/js directory.
@@ -23,8 +26,8 @@ try:
     with open(f'{root}/source/js/components/post-codes-list.json') as post_code_data:
         COUNTRY_POST_CODES = json.load(post_code_data)
 except Exception as error:
-    print('ERROR: could not read in post codes list')
-    print(error)
+    logger.exception('ERROR: could not read in post codes list')
+    logger.exception(error)
     COUNTRY_POST_CODES = None
 
 # Global maximum amount value of 10 million, not currency-specific, intended
@@ -76,7 +79,7 @@ class PostalCodeMixin():
         country = cleaned_data.get('country', '')
         # If we cannot import post-code data, default to it being required.
         if COUNTRY_POST_CODES is None:
-            print('Error: no postal code data available, defaulting to required(postal_code).')
+            logger.exception('Error: no postal code data available, defaulting to required(postal_code).')
             self.check_post_code(postal_code)
         # Checking if the country uses post-code by finding it in JSON data.
         elif 'postal' in next(country_obj for country_obj in COUNTRY_POST_CODES if country_obj["abbrev"] == country):

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -18,7 +18,7 @@ import json
 # # Loading a JSON list of countries and their respective post code formats if applicable,
 # # from the source/js directory.
 try:
-    with open('./source/js/components/post-codes-list.json') as post_code_data:
+    with open('../source/js/components/post-codes-list.json') as post_code_data:
         COUNTRY_POST_CODES = json.load(post_code_data)
 except Exception as error:
     print('ERROR: could not read in post codes list')

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -20,7 +20,9 @@ import json
 try:
     with open('./source/js/components/post-codes-list.json') as post_code_data:
         COUNTRY_POST_CODES = json.load(post_code_data)
-except Exception:
+except Exception as error:
+    print('ERROR: could not read in post codes list')
+    print(error)
     COUNTRY_POST_CODES = None
 
 # Global maximum amount value of 10 million, not currency-specific, intended
@@ -72,6 +74,7 @@ class PostalCodeMixin():
         country = cleaned_data.get('country', '')
         # If we cannot import post-code data, default to it being required.
         if COUNTRY_POST_CODES is None:
+            print('Error: no postal code data available, defaulting to required(postal_code)')
             self.check_post_code(postal_code)
         # Checking if the country uses post-code by finding it in JSON data.
         elif 'postal' in next(country_obj for country_obj in COUNTRY_POST_CODES if country_obj["abbrev"] == country):

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -15,8 +15,8 @@ from .utils import get_currency_info
 
 import json
 
-# # Loading a JSON list of countries and their respective post code formats if applicable,
-# # from the source/js directory.
+# Loading a JSON list of countries and their respective post code formats if applicable,
+# from the source/js directory.
 try:
     with open('/app/source/js/components/post-codes-list.json') as post_code_data:
         COUNTRY_POST_CODES = json.load(post_code_data)

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -74,7 +74,7 @@ class PostalCodeMixin():
         country = cleaned_data.get('country', '')
         # If we cannot import post-code data, default to it being required.
         if COUNTRY_POST_CODES is None:
-            print('Error: no postal code data available, defaulting to required(postal_code)')
+            print('Error: no postal code data available, defaulting to required(postal_code).')
             self.check_post_code(postal_code)
         # Checking if the country uses post-code by finding it in JSON data.
         elif 'postal' in next(country_obj for country_obj in COUNTRY_POST_CODES if country_obj["abbrev"] == country):

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -13,12 +13,14 @@ from donate.recaptcha.fields import ReCaptchaField
 from . import constants
 from .utils import get_currency_info
 
+from ..settings.environment import root
+
 import json
 
 # Loading a JSON list of countries and their respective post code formats if applicable,
 # from the source/js directory.
 try:
-    with open('/app/source/js/components/post-codes-list.json') as post_code_data:
+    with open(f'{root}/source/js/components/post-codes-list.json') as post_code_data:
         COUNTRY_POST_CODES = json.load(post_code_data)
 except Exception as error:
     print('ERROR: could not read in post codes list')

--- a/donate/templates/payment/thank_you_master.html
+++ b/donate/templates/payment/thank_you_master.html
@@ -12,8 +12,7 @@
             <h1 class="heading heading--primary heading--bottom-margin">{% trans "Thank you for your generous gift" %}</h1>
 
             {% block thank_you_description %}
-                <p>{% blocktrans %}Your donation will go right to work protecting the web, keeping it open and available to all.{% endblocktrans %} {% blocktrans with email='donate@mozilla.org' %}We’ve emailed you a donation receipt; if it’s missing, please check your junk/spam folders, then contact us at <a href="mailto:{{ email }}">{{ email }}</a>.{% endblocktrans %}</p>
-
+                <p>{% blocktrans with url='/help' %}We’ve emailed you a donation receipt; if it’s missing, please check your junk/spam folders, then contact us using <a href="{{ url }}">this form</a>.{% endblocktrans %}</p>
                 <p>{% trans "Lastly, can you multiply your impact by sharing about the important work Mozilla is doing? Thank you again!" %}</p>
             {% endblock %}
 


### PR DESCRIPTION
Closes #1518 
Related PRs/issues: #1535  (Investigatory PR)

**Steps to test**: 

1. Visit https://donate-wagta-postal-cod-ahiric.herokuapp.com/en-US/
2. Make a selection from one of the donation amounts, or enter a custom value.
3. Click the purple credit card payment button
4. Fill out the form, using the test credit card info below, and selecting "Hong Kong" as the country.
5. Click "Donate" and you should get redirected to the thank you page.
6. If redirected to thank you page, testing is done! 

**TEST CC INFO**:
Card Number: 4111 1111 1111 1111
EXP: 11/23
CVV: 123

## Checklist

**Changes in Models:**
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/master/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?