### PR TITLE
Fix campaign paypal donation

### DIFF
--- a/donate/templates/pages/core/campaign_page.html
+++ b/donate/templates/pages/core/campaign_page.html
@@ -77,6 +77,17 @@
                     {% include "fragments/messages.html" %}
                     {% include "fragments/donate_form.html" %}
                 </div>
+
+                <div class="donatation-pending hidden">
+                    <header class="donate-form__header">
+                        <h1 class="donate-form__heading heading heading--primary">
+                            {% trans "Your donation is being processed..." %}
+                        </h1>
+                    </header>
+                    <div class="donate-form__content">
+                        <div>{% trans "One moment while we get all the details right!" %}</div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/source/js/payments-card.js
+++ b/source/js/payments-card.js
@@ -177,8 +177,12 @@ function setupBraintree() {
     const props = {
       sitekey: recaptcha.dataset.publicKey,
       callback: (token) => {
-        captchaInput.value = token;
-        submitButton.removeAttribute("disabled");
+        try {
+          captchaInput.value = token;
+          submitButton.removeAttribute("disabled");
+        } catch (err) {
+          console.error(err);
+        }
       },
     };
 

--- a/source/js/payments-paypal.js
+++ b/source/js/payments-paypal.js
@@ -14,10 +14,12 @@ function setupBraintree() {
     currencySelect = document.getElementById("id_currency-switcher-currency");
 
   var getCurrency = () => currencySelect.value.toUpperCase();
+
   var getAmountSingle = () => {
     var donateForm = document.getElementById("donate-form--single");
     return donateForm.querySelector('input[name="amount"]:checked').value;
   };
+
   var onAuthorizeSingle = (payload) => {
     nonceInput.value = payload.nonce;
     amountInput.value = getAmountSingle();
@@ -29,10 +31,12 @@ function setupBraintree() {
       submitForm();
     }
   };
+
   var getAmountMonthly = () => {
     var donateForm = document.getElementById("donate-form--monthly");
     return donateForm.querySelector('input[name="amount"]:checked').value;
   };
+
   var onAuthorizeMonthly = (payload) => {
     nonceInput.value = payload.nonce;
     amountInput.value = getAmountMonthly();
@@ -52,6 +56,7 @@ function setupBraintree() {
     "checkout",
     "#payments__paypal-button--single"
   );
+
   initPaypal(
     getAmountMonthly,
     getCurrency,
@@ -77,8 +82,12 @@ function setupBraintree() {
       sitekey: recaptcha.dataset.publicKey,
       size: "invisible",
       callback: (token) => {
-        captchaInput.value = token;
-        submitForm();
+        try {
+          captchaInput.value = token;
+          submitForm();
+        } catch (err) {
+          console.error(err);
+        }
       },
     };
 

--- a/source/js/payments-paypal.js
+++ b/source/js/payments-paypal.js
@@ -62,7 +62,11 @@ function setupBraintree() {
 
   function submitForm() {
     donateForm.classList.add("hidden");
-    donationPending.classList.remove("hidden");
+    if (donationPending) {
+      donationPending.classList.remove("hidden");
+    } else {
+      console.warn(`payment-pending view missing`);
+    }
     paymentForm.submit();
   }
 


### PR DESCRIPTION
Closes https://github.com/mozilla/donate-wagtail/issues/1584
Closes https://github.com/mozilla/donate-wagtail/issues/1589

This problem can be reproduced and verified locally.

# confirm the problem
- check out master
- make sure that you're using the localhost recaptcha site/secret values in the `.env` file (see https://www.google.com/recaptcha/admin if you do not have those set up yet)
- start the localhost CMS
- in the CMS, create a new `campaign page` under the donate homepage
- copy the information from https://donate.mozilla.org/admin/pages/2809/edit (including the "promote" tab information)
- publish that page
- visit http://localhost:8000/en-US/2021eoy/?subscribed=1&utm_source=email&utm_medium=email&utm_campaign=202111_GivingTues&utm_content=GivingTuesV2Callout_kicker
- open dev tools
- click the paypal button, pick "debit or credit card"
- use 4111 credentials
- submit as guest
- the dev tools console will show a maddeningly unhelpful error once the paypal flow finishes

# confirm the solution
- check out this branch
- start the localhost CMS
- visit http://localhost:8000/en-US/2021eoy/?subscribed=1&utm_source=email&utm_medium=email&utm_campaign=202111_GivingTues&utm_content=GivingTuesV2Callout_kicker
- open dev tools
- click the paypal button, pick "debit or credit card"
- use 4111 credentials
- submit as guest
- you should now be shown the "we're processing your payment" screen upon paypal completion, followed by the thank you page after a short wait.