### PR TITLE
commented out references of crypto donations

### DIFF
--- a/donate/templates/fragments/donate_form_disclaimer_master.html
+++ b/donate/templates/fragments/donate_form_disclaimer_master.html
@@ -13,14 +13,17 @@
     </p>
     <p>
         {% block other_options %}
-        <b><!-- Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608
-            {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' cryptocurrency_url='https://bitpay.com/100257/donate' trimmed %}
-              Other ways to give: 
-              <a href="{{ wire_transfer_url }}">SEPA/BACS</a> | 
-              <a href="{{ check_url }}">Check</a> |
-              <a href="{{ cryptocurrency_url }}">BitPay (cryptocurrencies)</a>
-              
-            {% endblocktrans %} -->
+        <b>{% comment %}
+                Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608
+                
+                {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' cryptocurrency_url='https://bitpay.com/100257/donate' trimmed %}
+                Other ways to give: 
+                <a href="{{ wire_transfer_url }}">SEPA/BACS</a> | 
+                <a href="{{ check_url }}">Check</a> |
+                <a href="{{ cryptocurrency_url }}">BitPay (cryptocurrencies)</a>
+                
+                {% endblocktrans %}
+            {% endcomment %}
             {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' trimmed %}
               Other ways to give: 
               <a href="{{ wire_transfer_url }}">SEPA/BACS</a> | 

--- a/donate/templates/fragments/donate_form_disclaimer_master.html
+++ b/donate/templates/fragments/donate_form_disclaimer_master.html
@@ -13,13 +13,18 @@
     </p>
     <p>
         {% block other_options %}
-        <b>
-            {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' cryptocurrency_url='https://bitpay.com/100257/donate' %}
+        <b><!-- Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608
+            {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' cryptocurrency_url='https://bitpay.com/100257/donate' trimmed %}
               Other ways to give: 
               <a href="{{ wire_transfer_url }}">SEPA/BACS</a> | 
-              <a href="{{ check_url }}">Check</a> 
-              <!-- Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608 -->
-              <!-- | <a href="{{ cryptocurrency_url }}">BitPay (cryptocurrencies)</a> -->
+              <a href="{{ check_url }}">Check</a> |
+              <a href="{{ cryptocurrency_url }}">BitPay (cryptocurrencies)</a>
+              
+            {% endblocktrans %} -->
+            {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' trimmed %}
+              Other ways to give: 
+              <a href="{{ wire_transfer_url }}">SEPA/BACS</a> | 
+              <a href="{{ check_url }}">Check</a>
             {% endblocktrans %}
         </b>
         {% endblock %}

--- a/donate/templates/fragments/donate_form_disclaimer_master.html
+++ b/donate/templates/fragments/donate_form_disclaimer_master.html
@@ -14,7 +14,13 @@
     <p>
         {% block other_options %}
         <b>
-            {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' cryptocurrency_url='https://bitpay.com/100257/donate' %}Other ways to give: <a href="{{ wire_transfer_url }}">SEPA/BACS</a> | <a href="{{ check_url }}">Check</a> | <a href="{{ cryptocurrency_url }}">BitPay (cryptocurrencies)</a>{% endblocktrans %}
+            {% blocktrans with wire_transfer_url='/ways-to-give#wire' check_url='/ways-to-give#check' cryptocurrency_url='https://bitpay.com/100257/donate' %}
+              Other ways to give: 
+              <a href="{{ wire_transfer_url }}">SEPA/BACS</a> | 
+              <a href="{{ check_url }}">Check</a> 
+              <!-- Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608 -->
+              <!-- | <a href="{{ cryptocurrency_url }}">BitPay (cryptocurrencies)</a> -->
+            {% endblocktrans %}
         </b>
         {% endblock %}
     </p>

--- a/donate/templates/pages/core/ways_to_give_page_master.html
+++ b/donate/templates/pages/core/ways_to_give_page_master.html
@@ -129,21 +129,23 @@
             {% endfor %}
         </ul>
     {% endblock %}
-
-    <!-- Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608 -->
-    <!-- {% block cryptocurrencies %}
+    {% comment %}
+    Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608
+      {% block cryptocurrencies %}
         <h2>{% trans "Cryptocurrencies" %}</h2>
         <p>
-            {% blocktrans trimmed %}
+          {% blocktrans trimmed %}
             The Mozilla Foundation is a California non-profit corporation exempt from United States federal income taxation under IRC 501(c)(3) and a public charity classified under IRC sections 170(b)(1)(A) and 509(a)(1). Cryptocurrency donations Mozilla receives are considered charitable contributions under U.S. federal tax laws, to be used in its discretion for its charitable purposes. Because the IRS has indicated that it will treat cryptocurrencies as property for U.S. tax purposes (see IRS Notice 2014-21), cryptocurrency donations may be subject to special rules as to the amount of your charitable deduction, the documentation that must be provided to claim a tax deduction, or other matters.
-            {% endblocktrans %}
+          {% endblocktrans %}
         </p>
         <p>
-            {% blocktrans with cryptocurrency_wiki="https://wiki.mozilla.org/Donate_Bitcoin" cryptocurrency_url="https://bitpay.com/100257/donate" trimmed %}
+          {% blocktrans with cryptocurrency_wiki="https://wiki.mozilla.org/Donate_Bitcoin" cryptocurrency_url="https://bitpay.com/100257/donate" trimmed %}
             Learn more about cryptocurrency donations <a href="{{cryptocurrency_wiki}}">here</a>. To donate using cryptocurrency, <a href="{{cryptocurrency_url}}">please visit this link.</a>
-            {% endblocktrans %}
+          {% endblocktrans %}
         </p>
-    {% endblock %} -->
+      {% endblock %}
+    {% endcomment %}
+
 </div>
 
 {% endblock %}

--- a/donate/templates/pages/core/ways_to_give_page_master.html
+++ b/donate/templates/pages/core/ways_to_give_page_master.html
@@ -129,7 +129,9 @@
             {% endfor %}
         </ul>
     {% endblock %}
-    {% block cryptocurrencies %}
+
+    <!-- Temporarily commenting out crypto-donation info per request https://github.com/mozilla/donate-wagtail/issues/1608 -->
+    <!-- {% block cryptocurrencies %}
         <h2>{% trans "Cryptocurrencies" %}</h2>
         <p>
             {% blocktrans trimmed %}
@@ -141,7 +143,7 @@
             Learn more about cryptocurrency donations <a href="{{cryptocurrency_wiki}}">here</a>. To donate using cryptocurrency, <a href="{{cryptocurrency_url}}">please visit this link.</a>
             {% endblocktrans %}
         </p>
-    {% endblock %}
+    {% endblock %} -->
 </div>
 
 {% endblock %}


### PR DESCRIPTION
Closes #1608 
Related PRs/issues # https://github.com/mozilla/foundation.mozilla.org/issues/8011


**Steps to test**:

1. Visit https://donate-wagta-updated-do-ok21hz.herokuapp.com/en-US/ 
2. Note that the Bitpay option has been removed from "Other ways to give" 
3. Visit https://donate-wagta-updated-do-ok21hz.herokuapp.com/en-US/ways-to-give/
4. Note that the crypto section has been removed
5. If everything is looking as expected, testing is complete! 
