### PR TITLE
Update copy on Thunderbird "Ways to Give" page.

### DIFF
--- a/donate/thunderbird/templates/pages/core/ways_to_give_page.html
+++ b/donate/thunderbird/templates/pages/core/ways_to_give_page.html
@@ -51,14 +51,13 @@
 {% block stock_donations %}{% endblock %}
 
 {% block covid_notice %}
-    <b>{% trans "UPDATE October 2020:"%}</b>
     {% blocktrans trimmed %}
-    MZLA/Thunderbird is happy to accept your donation (made payable to “MZLA Technologies”) via check; however please note that processing and acknowledgment of your gift may be delayed by changes to our office procedures due to the COVID-19 pandemic. You can send checks to:
+    MZLA/Thunderbird is happy to accept your donation <strong>(made payable to “MZLA Technologies”)</strong> via check; however please note that processing and acknowledgment of your gift may be delayed by changes to our office procedures due to the COVID-19 pandemic. You can send checks to:
     {% endblocktrans %}
 {% endblock %}
 
 {% block check_address %}
-    Mozilla Foundation, attn: MZLA/Thunderbird Donor Care<br>
+    MZLA/Thunderbird Donor Care<br>
     2 Harrison Street, Suite 175<br>
     San Francisco, CA 94105
 {% endblock %}

--- a/donate/thunderbird/templates/pages/core/ways_to_give_page.html
+++ b/donate/thunderbird/templates/pages/core/ways_to_give_page.html
@@ -52,12 +52,13 @@
 
 {% block covid_notice %}
     {% blocktrans trimmed %}
-    MZLA/Thunderbird is happy to accept your donation <strong>(made payable to “MZLA Technologies”)</strong> via check; however please note that processing and acknowledgment of your gift may be delayed by changes to our office procedures due to the COVID-19 pandemic. You can send checks to:
+    MZLA/Thunderbird is happy to accept your donation <strong>(made payable to “MZLA Technologies Corp”)</strong> via check; however please note that processing and acknowledgment of your gift may be delayed by changes to our office procedures due to the COVID-19 pandemic. You can send checks to:
     {% endblocktrans %}
 {% endblock %}
 
 {% block check_address %}
-    MZLA/Thunderbird Donor Care<br>
+    MZLA Technologies Corporation<br>
+    Attn: Thunderbird Donor Care<br>
     2 Harrison Street, Suite 175<br>
     San Francisco, CA 94105
 {% endblock %}


### PR DESCRIPTION
- Remove unnecessary Mozilla Foundation text from mailing address.
- Make payable instruction bold.
- Remove "Update October 2020" as this just makes the text seem outdated.