### PR TITLE
added reworded error message

### DIFF
--- a/source/js/components/paypal.js
+++ b/source/js/components/paypal.js
@@ -17,7 +17,7 @@ export default function initPaypal(
     "There was an error processing your payment. Please try again."
   );
   var generalErrorMsg = window.gettext(
-    "Unable to connect to PayPal. Please try again in a few minutes."
+    "We were unable to establish a connection to PayPal. Please try again in a few minutes."
   );
   var braintreeParams = JSON.parse(
     document.getElementById("payments__braintree-params").textContent

--- a/source/js/components/paypal.js
+++ b/source/js/components/paypal.js
@@ -13,8 +13,11 @@ export default function initPaypal(
   var loadingErrorMsg = window.gettext(
     "An error occurred. Please reload the page or try again later."
   );
-  var generalErrorMsg = window.gettext(
+  var authErrorMsg = window.gettext(
     "There was an error processing your payment. Please try again."
+  );
+  var generalErrorMsg = window.gettext(
+    "Unable to connect to Paypal. Please try again in a few minutes."
   );
   var braintreeParams = JSON.parse(
     document.getElementById("payments__braintree-params").textContent
@@ -82,7 +85,7 @@ export default function initPaypal(
                   payload
                 ) {
                   if (err) {
-                    showErrorMessage(generalErrorMsg);
+                    showErrorMessage(authErrorMsg);
                     return;
                   }
 

--- a/source/js/components/paypal.js
+++ b/source/js/components/paypal.js
@@ -17,7 +17,7 @@ export default function initPaypal(
     "There was an error processing your payment. Please try again."
   );
   var generalErrorMsg = window.gettext(
-    "Unable to connect to Paypal. Please try again in a few minutes."
+    "Unable to connect to PayPal. Please try again in a few minutes."
   );
   var braintreeParams = JSON.parse(
     document.getElementById("payments__braintree-params").textContent


### PR DESCRIPTION
Closes #1635

**Steps to test**:
Testing is not really possible as the review apps use paypal/braintree sandbox mode.

However, here is a screenshot of what appears after following the same workflow that we have used to reproduce the error on my local machine:
<img width="828" alt="Screen Shot 2022-02-24 at 1 29 37 PM" src="https://user-images.githubusercontent.com/18314510/155611438-971d8c12-31df-456b-a307-8d2851d2810d.png">


I would also like to note that this new reworded error message only appears if there is a *general* error from paypal, which rate limiting is included in.

If the payment gets cancelled by the user, the "Payment cancelled" message still appears, and if there is an error authorizing the payment, the original "There was an error processing your payment. Please try again." error message gets rendered.

