### PR TITLE
now able to share using ?amount=other

### DIFF
--- a/donate/core/models.py
+++ b/donate/core/models.py
@@ -118,6 +118,14 @@ class DonationPage(Page):
         """
         return sorted(initial_currency_info['presets'][initial_frequency])[1]
 
+    def default_other_amount(self, initial_currency_info):
+        """
+        If ?amount = other, return value as minimum possible value.
+        We then check in the template if the 'value' is set to the minimum, and if so, highlight the
+        'other amount' field.
+        """
+        return initial_currency_info['minAmount']
+
     def get_initial_amount(self, request, initial_currency_info, initial_frequency):
         """
         When called with ?amount=..., that value will be preselected if:
@@ -128,6 +136,9 @@ class DonationPage(Page):
         If not, the default initial amount is used
         """
         amount = request.GET.get('amount', False)
+
+        if amount == 'other':
+            return self.default_other_amount(initial_currency_info)
 
         if amount is False or 'e' in amount:
             return self.default_initial_amount(initial_currency_info, initial_frequency)

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -36,7 +36,7 @@
                     {% endfor %}
                     <div class="donation-amount--two-col">
                         <div class="donation-amount donation-amount--other">
-                            <input type="radio" class="donation-amount__radio one-time-amount-donation-radio" name="amount" value="other" id="one-time-amount-other" autocomplete="off" data-other-amount-radio="">
+                            <input type="radio" class="donation-amount__radio one-time-amount-donation-radio" name="amount" value="other" id="one-time-amount-other" autocomplete="off" data-other-amount-radio="" {% if initial_amount == initial_currency_info.minAmount %}checked="checked"{% endif %}>
                             <label for="one-time-amount-other" class="donation-amount__label donation-amount-other__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                             <label for="one-time-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
                             <input type="number" class="donation-amount__input one-time-amount-other-input OG" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" min="{{ initial_currency_info.minAmount }}" max="10000000" data-other-amount="">


### PR DESCRIPTION
This PR is related to a request from @anilkanji where he would like people to be able to share the donate page with the "other" amount field highlighted. 

Ideally, I would like to open another ticket to improve/clean this up in the future, as this was requested to be ready by 11AM PST on 5/10/22