### PR TITLE
403 page l10n fixes

### DIFF
--- a/donate/templates/403.html
+++ b/donate/templates/403.html
@@ -13,8 +13,8 @@
     <div class="layout__container">
         <div class="layout__half-col error__container">
             <p class="error__message">
-                {% blocktrans with url="https://www.donate.mozilla.org" trimmed %}
-                Please disable your VPN and visit <a href="{{ url }}">donate.mozilla.org</a> again.
+                {% blocktrans with url="/" site=request.get_host trimmed %}
+                Please disable your VPN and visit <a href="{{ url }}">{{ site }}</a> again.
                 {% endblocktrans %}
             </p>
             <p class="error__message">

--- a/donate/templates/403.html
+++ b/donate/templates/403.html
@@ -12,10 +12,12 @@
     </div>
     <div class="layout__container">
         <div class="layout__half-col error__container">
-            {% blocktrans %}
-              <p class="error__message">Please disable your VPN and visit <a href="https://www.donate.mozilla.org"> donate.mozilla.org </a> again.</p>
-            {% endblocktrans %}
-          <p class="error__message">
+            <p class="error__message">
+                {% blocktrans with url="https://www.donate.mozilla.org" trimmed %}
+                Please disable your VPN and visit <a href="{{ url }}">donate.mozilla.org</a> again.
+                {% endblocktrans %}
+            </p>
+            <p class="error__message">
               {% trans "We take your privacy very seriously. To minimize fraudulent payments, we’re asking supporters to disable their VPNs when visiting our donate page." %}
             </p>
         </div>


### PR DESCRIPTION
Follow-up from https://github.com/mozilla/donate-wagtail/pull/1657


Hi @danielfmiranda, would you mind reviewing this quick localization fix for the 403 page?

Basically, here’s what it does and why, because it’s not intuitive:
- Moving HTML tags outside the string when possible — here we can move the `<p></p>` outside, to avoid any alteration by mistake from translators as well as unnecessary retranslation in case we touch that code in the future.
- Moving the URL to a variable, for the same reasons
- Adding the "trimmed" option to `blocktrans`, to remove leading/trailing spaces that are adding noise to translations