### PR TITLE
Updated text for mozilla donate help page

### DIFF
--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -69,8 +69,13 @@
                             {% endblocktrans %}
                         </p>
                         <p class="rich-text">
-                            {% blocktrans with support_url="https://support.mozilla.org/questions/firefox" trimmed %}
-                                Unfortunately, donor care representatives are unable to offer support or help with Firefox technical issues. For technical support, please visit the <a href="{{ support_url }}">Firefox support page</a>.
+                            {% blocktrans trimmed %}
+                                Unfortunately, donor care representatives are unable to offer support or help with Firefox technical issues, or changes to or questions about Mozilla VPN subscriptions. Related questions submitted through this form will not be responded to.
+                            {% endblocktrans %}
+                        </p>
+                        <p class="rich-text">
+                            {% blocktrans with firefox_support_url="https://support.mozilla.org/questions/firefox" vpn_support_url="https://support.mozilla.org/products/firefox-private-network-vpn" trimmed %}
+                                For technical support, please visit the <a href="{{ firefox_support_url }}"> Firefox support page </a>. For help with a VPN subscription, please visit the <a href="{{ vpn_support_url }}"> Mozilla VPN Support page </a>.
                             {% endblocktrans %}
                         </p>
                     {% endblock %}

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -75,7 +75,7 @@
                         </p>
                         <p class="rich-text">
                             {% blocktrans with firefox_support_url="https://support.mozilla.org/questions/firefox" vpn_support_url="https://support.mozilla.org/products/firefox-private-network-vpn" trimmed %}
-                                For technical support, please visit the <a href="{{ firefox_support_url }}"> Firefox support page </a>. For help with a VPN subscription, please visit the <a href="{{ vpn_support_url }}"> Mozilla VPN Support page </a>.
+                                For technical support, please visit the <a href="{{ firefox_support_url }}">Firefox support page</a>. For help with a VPN subscription, please visit the <a href="{{ vpn_support_url }}">Mozilla VPN Support page</a>.
                             {% endblocktrans %}
                         </p>
                     {% endblock %}


### PR DESCRIPTION
Closes #1668


This PR updates the Mozilla donate sites help page copy from:

> If you need help with a donation to the Mozilla Foundation, please fill out this form and a donor care representative will get back to you as soon as possible.
> 
> Unfortunately, donor care representatives are unable to offer support or help with Firefox technical issues. For technical support, please visit the [Firefox support page](https://support.mozilla.org/questions/firefox).

To:

> If you need help with a donation to the Mozilla Foundation, please fill out this form and a donor care representative will get back to you as soon as possible.
> 
> Unfortunately, donor care representatives are unable to offer support or help with Firefox technical issues, or changes to or questions about Mozilla VPN subscriptions. Related questions submitted through this form will not be responded to.
> 
> For technical support, please visit the [Firefox support page](https://support.mozilla.org/questions/firefox). For help with a VPN subscription, please visit the [Mozilla VPN Support page](https://support.mozilla.org/products/firefox-private-network-vpn)
> 



Screenshots:
---
New Copy:

<img width="539" alt="Screen Shot 2022-07-05 at 4 28 37 PM" src="https://user-images.githubusercontent.com/18314510/177434607-589aee09-e5d0-4807-877a-9a977e801b85.png">

