### PR TITLE
updated all inline scripts to use the generated nonce value

### DIFF
--- a/donate/templates/fragments/ga_events.html
+++ b/donate/templates/fragments/ga_events.html
@@ -2,7 +2,7 @@
 
 {% if data_layer %}
   {{ data_layer|json_script:"data_layer" }}
-  <script>
+  <script nonce="{{request.csp_nonce}}">
     const transactionData = JSON.parse(document.querySelector('#data_layer').textContent)[0][0];
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push(transactionData);

--- a/donate/templates/fragments/ga_events.html
+++ b/donate/templates/fragments/ga_events.html
@@ -2,7 +2,7 @@
 
 {% if data_layer %}
   {{ data_layer|json_script:"data_layer" }}
-  <script nonce="{{request.csp_nonce}}">
+  <script nonce="{{ request.csp_nonce }}">
     const transactionData = JSON.parse(document.querySelector('#data_layer').textContent)[0][0];
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push(transactionData);

--- a/donate/templates/payment/includes/trigger_ab_testing_thank_you_event.html
+++ b/donate/templates/payment/includes/trigger_ab_testing_thank_you_event.html
@@ -1,4 +1,4 @@
-<script nonce="{{request.csp_nonce}}">
+<script nonce="{{ request.csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function () {
         // Try to send an A/B signal to the wagtail A/B testing framework
         (function tryWagtailABEvent(count) {

--- a/donate/templates/payment/includes/trigger_ab_testing_thank_you_event.html
+++ b/donate/templates/payment/includes/trigger_ab_testing_thank_you_event.html
@@ -1,4 +1,4 @@
-<script>
+<script nonce="{{request.csp_nonce}}">
     document.addEventListener('DOMContentLoaded', function () {
         // Try to send an A/B signal to the wagtail A/B testing framework
         (function tryWagtailABEvent(count) {


### PR DESCRIPTION
Closed #1682

Since we have updated the django_csp package to now add a nonce value to CSP_SCRIPT_SRC, that means we have to pass that nonce value to any inline scripts in the code base or else they wont run. 

I have searched the whole code base to check for any inline scripts, I found a total of two (though both of these scripts are only rendered if someone is doing AB testing) and have updated them to include the nonce, just in case.