### PR TITLE
added path for 403 template for WAF to point to

### DIFF
--- a/donate/urls.py
+++ b/donate/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('stripe/webhook/', StripeWebhookView.as_view(), name='stripe_webhook'),
     path('environment.json', EnvVariablesView.as_view()),
     path('abtesting/', include(ab_testing_urls)),
+    path('403/', TemplateView.as_view(template_name='403.html')),
 ]
 
 if settings.ENABLE_THUNDERBIRD_REDIRECT:


### PR DESCRIPTION
Related PRs/issues #1657

This PR introduces a new path to the 403 template that the WAF can point to, instead of being overridden by cloudfront