### PR TITLE
updated except to include read time out error

### DIFF
--- a/donate/utility/acoustic/acoustic.py
+++ b/donate/utility/acoustic/acoustic.py
@@ -144,7 +144,7 @@ class AcousticTransact(Silverpop):
                     logger.error(
                         f"Could not send email receipt. Unable to connect to Acoustic after {send_retries} retries."
                     )
-                    logger.error(err)
+                    logger.error(f"Error: {err}")
 
                 continue
 

--- a/donate/utility/acoustic/acoustic.py
+++ b/donate/utility/acoustic/acoustic.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.utils.encoding import force_bytes
 
 from lxml import etree
-from requests import ConnectionError
+from requests import ConnectionError, ReadTimeout
 from silverpop.api import Silverpop, SilverpopResponseException
 
 
@@ -137,13 +137,14 @@ class AcousticTransact(Silverpop):
                 # explicitly block, just in case the implicit behaviour changes in the future
                 schedule.run(blocking=True)
                 break
-            except ConnectionError:
+            except (ConnectionError, ReadTimeout) as err:
                 if attempt != 2:
-                    logger.error("Error connecting to Acoustic to send email receipt. Trying again.")
+                    logger.error("Error connecting to Acoustic while sending email receipt. Trying again.")
                 else:
                     logger.error(
-                        f"Could not send email receipt. Unable to connect to Acoustic {send_retries} retries."
+                        f"Could not send email receipt. Unable to connect to Acoustic after {send_retries} retries."
                     )
+                    logger.error(err)
 
                 continue
 


### PR DESCRIPTION
Closes #1688 

This PR adds `ReadTimeout` to the list of exceptions to catch when trying to send email reciepts through acoustic. 
If acoustic tries 3 times and still fails, we log an error message letting us know that we were not able to send the email, and then we log the captured exception message for more details

## Checklist

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~[Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/master/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the documentation?~~
