### PR TITLE
disabled `ways-to-give` route

### DIFF
--- a/donate/urls.py
+++ b/donate/urls.py
@@ -15,7 +15,7 @@ from wagtail_ab_testing import urls as ab_testing_urls
 from donate.payments import urls as payments_urls
 from donate.payments.braintree_webhooks import BraintreeWebhookView
 from donate.payments.stripe_webhooks import StripeWebhookView
-from donate.views import EnvVariablesView, ThunderbirdRedirectView, WaysToGiveView, apple_pay_domain_association_view
+from donate.views import EnvVariablesView, ThunderbirdRedirectView, apple_pay_domain_association_view
 
 # Patterns not subject to i18n
 urlpatterns = [

--- a/donate/urls.py
+++ b/donate/urls.py
@@ -42,7 +42,9 @@ urlpatterns += i18n_patterns(
     # See https://django-statici18n.readthedocs.io
     path('jsi18n/', cache_page(86400)(JavaScriptCatalog.as_view()), name='javascript-catalog'),
     path('', include(payments_urls)),
-    path('ways-to-give/', WaysToGiveView.as_view(), name='ways_to_give'),
+    # Ways to give view is commented out as we are now hosting that page on foundation.mozilla.org.
+    # For more info, see: https://github.com/MozillaFoundation/donate-wagtail/issues/1770
+    # path('ways-to-give/', WaysToGiveView.as_view(), name='ways_to_give'),
     path('403/', TemplateView.as_view(template_name='403.html')),
 
     # set up set language redirect view


### PR DESCRIPTION
# Description
Closes #1770


Per request of the Donate Team, we are disabling the existing `WaysToGive` route from the donate stack, and implementing a redirect in its place so when users visit `donate.mozilla.org/en-US/ways-to-give`, they get redirected to `foundation.mozilla.org/en/donate/ways-to-give` instead!

# Steps to test
1. Visit https://donate-wagta-1770-hide--bjnuwq.herokuapp.com/en-US/ways-to-give/
2. Note that you now receive a 404 page instead of the "Ways-to-give" page. 
3. If the 404 Page is appearing, testing is complete! The redirect has already been implemented on production.
4. If you would like to test the redirect, visit https://donate.mozilla.org/ways-to-give/. Note that it redirects you to https://foundation.mozilla.org/en/donate/ways-to-give/